### PR TITLE
Fix Facebook/Instagram Page fetch missing New Pages Experience pages

### DIFF
--- a/app/Http/Controllers/Auth/FacebookController.php
+++ b/app/Http/Controllers/Auth/FacebookController.php
@@ -32,6 +32,10 @@ class FacebookController extends SocialController
         'pages_read_engagement',
         'pages_manage_posts',
         'read_insights',
+        // Needed for the Business Manager fallback in fetchPages() - /me/accounts
+        // omits Pages under the New Pages Experience model, and reaching those
+        // via /me/businesses + owned_pages requires this scope.
+        'business_management',
     ];
 
     public function connect(Request $request): Response
@@ -272,6 +276,15 @@ class FacebookController extends SocialController
             ],
         );
 
+        // /me/accounts silently omits Pages that live under Meta's newer "New
+        // Pages Experience" / Business Portfolio model, even when the token's
+        // granular scopes show the Page was explicitly granted (confirmed via
+        // Meta's own Access Token Debugger, 2026-08-16). Falling back through
+        // Business Manager's owned_pages picks those up.
+        if (empty($pages)) {
+            $pages = $this->fetchPagesViaBusinessManager($userToken);
+        }
+
         return collect($pages)->map(fn (array $page) => [
             'id' => data_get($page, 'id'),
             'name' => data_get($page, 'name'),
@@ -279,6 +292,52 @@ class FacebookController extends SocialController
             'picture' => data_get($page, 'picture.data.url'),
             'access_token' => data_get($page, 'access_token'),
         ])->all();
+    }
+
+    private function fetchPagesViaBusinessManager(string $userToken): array
+    {
+        $businesses = GraphPaginator::all(
+            config('trypost.platforms.facebook.graph_api').'/me/businesses',
+            [
+                'access_token' => $userToken,
+                'fields' => 'id',
+                'limit' => 100,
+            ],
+        );
+
+        $pages = collect();
+
+        foreach ($businesses as $business) {
+            $businessId = data_get($business, 'id');
+
+            if (! $businessId) {
+                continue;
+            }
+
+            foreach (['owned_pages', 'client_pages'] as $edge) {
+                try {
+                    $edgePages = GraphPaginator::all(
+                        config('trypost.platforms.facebook.graph_api')."/{$businessId}/{$edge}",
+                        [
+                            'access_token' => $userToken,
+                            'fields' => 'id,name,username,picture{url},access_token',
+                            'limit' => 100,
+                        ],
+                    );
+                } catch (\Throwable $e) {
+                    Log::warning("Facebook Business Manager {$edge} lookup failed", [
+                        'business_id' => $businessId,
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    continue;
+                }
+
+                $pages = $pages->concat($edgePages);
+            }
+        }
+
+        return $pages->unique(fn (array $page) => data_get($page, 'id'))->values()->all();
     }
 
     private function graphVersion(): string

--- a/app/Http/Controllers/Auth/InstagramFacebookController.php
+++ b/app/Http/Controllers/Auth/InstagramFacebookController.php
@@ -235,12 +235,21 @@ class InstagramFacebookController extends SocialController
     private function fetchPagesWithInstagram(string $userToken): array
     {
         $graphApi = (string) config('trypost.platforms.instagram-facebook.graph_api');
+        $fields = 'id,name,username,picture{url},access_token,instagram_business_account';
 
         $pages = GraphPaginator::all("{$graphApi}/me/accounts", [
             'access_token' => $userToken,
-            'fields' => 'id,name,username,picture{url},access_token,instagram_business_account',
+            'fields' => $fields,
             'limit' => 100,
         ]);
+
+        // /me/accounts silently omits Pages that live under Meta's newer "New
+        // Pages Experience" / Business Portfolio model (confirmed via Meta's own
+        // Access Token Debugger, 2026-08-16). Fall back through Business
+        // Manager's owned_pages/client_pages, same fix as FacebookController.
+        if (empty($pages)) {
+            $pages = $this->fetchPagesViaBusinessManager($userToken, $graphApi, $fields);
+        }
 
         return collect($pages)
             ->filter(fn (array $page) => filled(data_get($page, 'instagram_business_account.id')))
@@ -273,6 +282,46 @@ class InstagramFacebookController extends SocialController
             })
             ->values()
             ->all();
+    }
+
+    private function fetchPagesViaBusinessManager(string $userToken, string $graphApi, string $fields): array
+    {
+        $businesses = GraphPaginator::all("{$graphApi}/me/businesses", [
+            'access_token' => $userToken,
+            'fields' => 'id',
+            'limit' => 100,
+        ]);
+
+        $pages = collect();
+
+        foreach ($businesses as $business) {
+            $businessId = data_get($business, 'id');
+
+            if (! $businessId) {
+                continue;
+            }
+
+            foreach (['owned_pages', 'client_pages'] as $edge) {
+                try {
+                    $edgePages = GraphPaginator::all("{$graphApi}/{$businessId}/{$edge}", [
+                        'access_token' => $userToken,
+                        'fields' => $fields,
+                        'limit' => 100,
+                    ]);
+                } catch (\Throwable $e) {
+                    Log::warning("Instagram-via-Facebook Business Manager {$edge} lookup failed", [
+                        'business_id' => $businessId,
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    continue;
+                }
+
+                $pages = $pages->concat($edgePages);
+            }
+        }
+
+        return $pages->unique(fn (array $page) => data_get($page, 'id'))->values()->all();
     }
 
     private function graphVersion(): string


### PR DESCRIPTION
## Summary
- `/me/accounts` silently omits Pages under Meta's newer "New Pages Experience" / Business Portfolio model - confirmed via Meta's own Access Token Debugger against a live account where the token's granular scopes showed the Page was explicitly granted (`pages_show_list`, `pages_read_engagement`, `pages_manage_posts` all scoped to the Page's ID), yet `/me/accounts` returned an empty list. Querying the Page node directly by ID worked fine.
- This surfaces to users as "No Facebook Pages found. You need to be an admin of at least one page." even though they are.
- Added a fallback in both `FacebookController::fetchPages()` and `InstagramFacebookController::fetchPagesWithInstagram()`: when `/me/accounts` comes back empty, fall through to Business Manager's `owned_pages`/`client_pages` edges (via `/me/businesses`), using the `business_management` scope (already requested by the Instagram-via-Facebook flow; added to the Facebook flow's scope list in this PR).

## Test plan
- [x] Reproduced against a live self-hosted instance: `/me/accounts` empty for an admin's own New Pages Experience Page, confirmed via Meta's Access Token Debugger that the grant was real and page-scoped, confirmed direct page-ID query worked.
- [x] Applied the fallback, rebuilt, reconnected the same account/Page - Page now found and connected successfully, published a real post through it.
- [ ] Would appreciate a maintainer/community check against a "New Pages Experience" Page under a Business Portfolio with multiple pages, to confirm the selection flow (`selectPage`/`select`) still behaves correctly when the fallback path returns more than one Page.

(Reopened from #291, which accidentally included unrelated commits from our fork's own main branch - this one contains only the fix, based directly on upstream main.)