### PR TITLE
Remove the X API reads that buy nothing

### DIFF
--- a/app/Console/Commands/RefreshExpiringTokens.php
+++ b/app/Console/Commands/RefreshExpiringTokens.php
@@ -18,10 +18,10 @@ class RefreshExpiringTokens extends Command
     protected $description = 'Proactively refresh social tokens before they expire';
 
     /**
-     * Rotating refresh_token platforms only need a short lead: verify() won't
-     * rotate a still-valid token, so we catch them right before or after expiry.
-     * Extension-model platforms (Instagram/Threads) can't be refreshed once
-     * expired, so they get a much wider lead to survive queue backlog.
+     * Rotating refresh_token platforms get a short lead: RefreshSocialToken
+     * rotates on every run, so a wider window would only rotate more often for
+     * no gain. Extension-model platforms (Instagram/Threads) can't be refreshed
+     * once expired, so they get a much wider lead to survive queue backlog.
      */
     public function handle(): void
     {

--- a/app/Console/Commands/RefreshExpiringTokens.php
+++ b/app/Console/Commands/RefreshExpiringTokens.php
@@ -18,10 +18,9 @@ class RefreshExpiringTokens extends Command
     protected $description = 'Proactively refresh social tokens before they expire';
 
     /**
-     * Rotating refresh_token platforms get a short lead: RefreshSocialToken
-     * rotates on every run, so a wider window would only rotate more often for
-     * no gain. Extension-model platforms (Instagram/Threads) can't be refreshed
-     * once expired, so they get a much wider lead to survive queue backlog.
+     * Rotating platforms get a short lead — a wider window would only rotate
+     * more often. Instagram and Threads can't be refreshed once expired, so
+     * theirs is wide enough to survive queue backlog.
      */
     public function handle(): void
     {
@@ -46,10 +45,8 @@ class RefreshExpiringTokens extends Command
                 }
             });
 
-        // Accounts in the window, not jobs queued: RefreshSocialToken is unique
-        // per account, so a dispatch is discarded while another is still in
-        // flight — and a dispatched count would overstate itself during exactly
-        // the backlog an operator reads this line to diagnose.
+        // Accounts in the window, not jobs queued: the job is unique per
+        // account, so a dispatch during a backlog is silently discarded.
         $this->info("{$count} accounts due for a token refresh.");
     }
 }

--- a/app/Console/Commands/RefreshExpiringTokens.php
+++ b/app/Console/Commands/RefreshExpiringTokens.php
@@ -46,6 +46,10 @@ class RefreshExpiringTokens extends Command
                 }
             });
 
-        $this->info("Dispatched {$count} token refresh jobs.");
+        // Accounts in the window, not jobs queued: RefreshSocialToken is unique
+        // per account, so a dispatch is discarded while another is still in
+        // flight — and a dispatched count would overstate itself during exactly
+        // the backlog an operator reads this line to diagnose.
+        $this->info("{$count} accounts due for a token refresh.");
     }
 }

--- a/app/Http/Controllers/App/AnalyticsController.php
+++ b/app/Http/Controllers/App/AnalyticsController.php
@@ -72,7 +72,10 @@ class AnalyticsController extends Controller
         $since = $request->has('since') ? Carbon::parse($request->input('since')) : null;
         $until = $request->has('until') ? Carbon::parse($request->input('until')) : null;
 
-        $metrics = match ($account->platform) {
+        // A transient platform failure — the provider being down, or a token
+        // refresh this request collided with — is not a server error. Empty
+        // numbers beat a 500 on a page the user just opened.
+        $metrics = rescue(fn () => match ($account->platform) {
             Platform::TikTok => app(TikTokAnalytics::class)->getMetrics($account),
             Platform::Instagram, Platform::InstagramFacebook => app(InstagramAnalytics::class)->getMetrics($account, $since, $until),
             Platform::Threads => app(ThreadsAnalytics::class)->getMetrics($account, $since, $until),
@@ -83,7 +86,7 @@ class AnalyticsController extends Controller
             Platform::YouTube => app(YouTubeAnalytics::class)->getMetrics($account, $since, $until),
             Platform::Telegram => app(TelegramAnalytics::class)->getMetrics($account),
             default => [],
-        };
+        }, [], report: true);
 
         return response()->json(['metrics' => $metrics]);
     }

--- a/app/Http/Controllers/App/AnalyticsController.php
+++ b/app/Http/Controllers/App/AnalyticsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\App;
 
 use App\Enums\SocialAccount\Platform;
+use App\Exceptions\PlatformUnavailableException;
 use App\Http\Controllers\Controller;
 use App\Models\SocialAccount;
 use App\Services\Social\FacebookAnalytics;
@@ -16,6 +17,7 @@ use App\Services\Social\ThreadsAnalytics;
 use App\Services\Social\TikTokAnalytics;
 use App\Services\Social\XAnalytics;
 use App\Services\Social\YouTubeAnalytics;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
@@ -72,22 +74,41 @@ class AnalyticsController extends Controller
         $since = $request->has('since') ? Carbon::parse($request->input('since')) : null;
         $until = $request->has('until') ? Carbon::parse($request->input('until')) : null;
 
-        // A transient platform failure — the provider being down, or a token
-        // refresh this request collided with — is not a server error. Empty
-        // numbers beat a 500 on a page the user just opened.
-        $metrics = rescue(fn () => match ($account->platform) {
-            Platform::TikTok => app(TikTokAnalytics::class)->getMetrics($account),
-            Platform::Instagram, Platform::InstagramFacebook => app(InstagramAnalytics::class)->getMetrics($account, $since, $until),
-            Platform::Threads => app(ThreadsAnalytics::class)->getMetrics($account, $since, $until),
-            Platform::Facebook => app(FacebookAnalytics::class)->getMetrics($account, $since, $until),
-            Platform::X => app(XAnalytics::class)->getMetrics($account, $since, $until),
-            Platform::LinkedInPage => app(LinkedInPageAnalytics::class)->getMetrics($account, $since, $until),
-            Platform::Pinterest => app(PinterestAnalytics::class)->getMetrics($account, $since, $until),
-            Platform::YouTube => app(YouTubeAnalytics::class)->getMetrics($account, $since, $until),
-            Platform::Telegram => app(TelegramAnalytics::class)->getMetrics($account),
-            default => [],
-        }, [], report: true);
+        $metrics = $this->metricsFor($account, $since, $until);
 
         return response()->json(['metrics' => $metrics]);
+    }
+
+    /**
+     * A platform being unreachable is not a server error: empty numbers beat a
+     * 500 on a page the user just opened, and a token refresh this request
+     * collided with resolves itself within seconds.
+     *
+     * Narrow on purpose. rescue() would have caught Throwable, so a defect in
+     * any metrics service would render as "this account has no activity" with
+     * nothing but a log line to say otherwise.
+     *
+     * @return array<int, array{label: string, value: int|string}>
+     */
+    private function metricsFor(SocialAccount $account, ?Carbon $since, ?Carbon $until): array
+    {
+        try {
+            return match ($account->platform) {
+                Platform::TikTok => app(TikTokAnalytics::class)->getMetrics($account),
+                Platform::Instagram, Platform::InstagramFacebook => app(InstagramAnalytics::class)->getMetrics($account, $since, $until),
+                Platform::Threads => app(ThreadsAnalytics::class)->getMetrics($account, $since, $until),
+                Platform::Facebook => app(FacebookAnalytics::class)->getMetrics($account, $since, $until),
+                Platform::X => app(XAnalytics::class)->getMetrics($account, $since, $until),
+                Platform::LinkedInPage => app(LinkedInPageAnalytics::class)->getMetrics($account, $since, $until),
+                Platform::Pinterest => app(PinterestAnalytics::class)->getMetrics($account, $since, $until),
+                Platform::YouTube => app(YouTubeAnalytics::class)->getMetrics($account, $since, $until),
+                Platform::Telegram => app(TelegramAnalytics::class)->getMetrics($account),
+                default => [],
+            };
+        } catch (PlatformUnavailableException|ConnectionException $e) {
+            report($e);
+
+            return [];
+        }
     }
 }

--- a/app/Http/Controllers/App/AnalyticsController.php
+++ b/app/Http/Controllers/App/AnalyticsController.php
@@ -80,13 +80,9 @@ class AnalyticsController extends Controller
     }
 
     /**
-     * A platform being unreachable is not a server error: empty numbers beat a
-     * 500 on a page the user just opened, and a token refresh this request
-     * collided with resolves itself within seconds.
-     *
-     * Narrow on purpose. rescue() would have caught Throwable, so a defect in
-     * any metrics service would render as "this account has no activity" with
-     * nothing but a log line to say otherwise.
+     * An unreachable platform is not a server error — empty numbers beat a 500
+     * on a page the user just opened. Narrow on purpose: catching Throwable
+     * would render a defect as "this account has no activity".
      *
      * @return array<int, array{label: string, value: int|string}>
      */

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -35,8 +35,9 @@ class RefreshSocialToken implements ShouldQueue
     public function handle(ConnectionVerifier $verifier): void
     {
         try {
-            $verifier->refreshToken($this->account);
-            $this->recordVerification();
+            if ($verifier->refreshToken($this->account)) {
+                $this->recordVerification();
+            }
         } catch (PlatformUnavailableException $e) {
             Log::warning('Token refresh skipped: platform unavailable', [
                 'account_id' => $this->account->id,
@@ -99,8 +100,7 @@ class RefreshSocialToken implements ShouldQueue
      * Record the refresh as a verification, so the daily sweep and the
      * pre-publish check can skip their own (often billed) verify call.
      *
-     * Only a refresh that actually happened proves anything, and only one that
-     * came back with a usable token: TokenRefreshClient classifies on HTTP
+     * Only a refresh that came back with a usable token proves anything: TokenRefreshClient classifies on HTTP
      * status alone and never inspects the body, so a 200 carrying an empty
      * token would otherwise be recorded as healthy. This is deliberately not
      * done inside ConnectionVerifier::refreshToken() — refreshThenVerify()

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -74,10 +74,13 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
 
     /**
      * A rejected refresh does not on its own mean the connection is dead.
-     * Providers that single-use their refresh_token (X, LinkedIn) reject one a
-     * concurrent refresh already consumed while the current access_token keeps
-     * working, and an account with no refresh_token at all fails here without
-     * any call being made. PublishToSocialPlatform hard-fails every post for a
+     * X and Bluesky single-use their refresh_token — X issues a new one and
+     * invalidates the previous on every refresh, and refreshSession returns a
+     * mandatory new refreshJwt — so one a concurrent refresh already consumed
+     * is rejected while the current access_token keeps working. X is also
+     * documented by its own developer community to invalidate refresh_tokens
+     * spuriously. An account with no refresh_token at all fails here without
+     * any call being made at all. PublishToSocialPlatform hard-fails every post for a
      * TokenExpired account, so disconnecting on a refresh rejection alone kills
      * posts the access_token would still have published.
      *

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -49,6 +49,16 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
     {
         try {
             if ($verifier->refreshToken($this->account)) {
+                if (blank($this->account->access_token)) {
+                    // The refresh method stored whatever came back and pushed
+                    // token_expires_at forward, so the account would otherwise
+                    // leave the refresh window looking healthy while every
+                    // publish 401s on an empty token.
+                    $this->account->markAsTokenExpired('Token refresh returned an empty access token');
+
+                    return;
+                }
+
                 $this->recordVerification();
             }
         } catch (PlatformUnavailableException $e) {
@@ -58,7 +68,7 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
                 'error' => $e->getMessage(),
             ]);
         } catch (TokenExpiredException $e) {
-            if ($this->accessTokenStillWorks($verifier)) {
+            if ($this->shouldTrustAWorkingAccessToken() && $this->accessTokenStillWorks($verifier)) {
                 return;
             }
 
@@ -95,9 +105,11 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
         // flight, which is why ours was rejected. This instance still holds the
         // token that was rotated away, so reload before judging it — otherwise
         // the winner's healthy account gets disconnected.
-        $this->account->refresh();
-
         try {
+            // Inside the try: the account can be deleted mid-run, and this job
+            // has tries = 1, so an escaping ModelNotFoundException fails it.
+            $this->account->refresh();
+
             return $verifier->verifyAccessToken($this->account);
         } catch (TokenExpiredException) {
             return false;
@@ -113,12 +125,28 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
     }
 
     /**
+     * Whether a working access token is reason enough to stay connected after a
+     * refresh was rejected.
+     *
+     * It is for platforms that rotate a refresh_token, where a rejection often
+     * just means we lost a race and the current token is fine. It is not for
+     * Instagram and Threads: their long-lived token is extended in place and
+     * cannot be renewed once it expires, so a permanently rejected extension
+     * means the connection is already doomed. Staying connected because the
+     * token still reads would tell the owner only after it dies, when
+     * reconnecting is the only option left, and would keep retrying the
+     * rejected extension every 15 minutes across the whole 24-hour lead.
+     */
+    private function shouldTrustAWorkingAccessToken(): bool
+    {
+        return ! $this->account->platform->extendsAccessTokenOnRefresh();
+    }
+
+    /**
      * Record the refresh as a verification, so the daily sweep and the
      * pre-publish check can skip their own (often billed) verify call.
      *
-     * Only a refresh that came back with a usable token proves anything: TokenRefreshClient classifies on HTTP
-     * status alone and never inspects the body, so a 200 carrying an empty
-     * token would otherwise be recorded as healthy. This is deliberately not
+     * Deliberately not
      * done inside ConnectionVerifier::refreshToken() — refreshThenVerify()
      * calls it and can still fail on the verify that follows, and a stamp
      * written there would vouch for a credential nothing ever confirmed.
@@ -126,10 +154,6 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
     private function recordVerification(): void
     {
         if (! $this->account->platform->hasTokenRefreshFlow()) {
-            return;
-        }
-
-        if (blank($this->account->access_token)) {
             return;
         }
 

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -22,11 +22,8 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
 
     public int $tries = 1;
 
-    // Covers the full schedule cadence. RefreshExpiringTokens re-selects an
-    // account until its token_expires_at moves, which only happens once this
-    // job runs — so a backlogged queue would otherwise stack a job per tick,
-    // each rotating a single-use refresh_token again for nothing and widening
-    // the window where a worker death loses the pair.
+    // token_expires_at only moves once this job runs, so a backlogged queue
+    // would stack one job per tick for the same account.
     public int $uniqueFor = 900;
 
     public function __construct(public SocialAccount $account) {}
@@ -37,15 +34,9 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
     }
 
     /**
-     * Refresh the token outright rather than verifying it first.
-     *
-     * A successful refresh already proves the credential is alive — the
-     * provider rejects a revoked one with a 4xx — so the verify endpoint adds
-     * nothing but cost. On X that endpoint is `GET /2/users/me`, billed as a
-     * "User: Read", and verifying a still-valid token left `token_expires_at`
-     * untouched: the account stayed inside RefreshExpiringTokens' window and
-     * was re-read every 15 minutes until the token actually died, which also
-     * left it expired for the stretch between expiry and the next tick.
+     * Refresh outright rather than verifying first: a refresh replaces the
+     * access token, leaving nothing for a verify call — billed as a "User:
+     * Read" on X — to confirm.
      */
     public function handle(ConnectionVerifier $verifier): void
     {
@@ -60,7 +51,12 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
                 'error' => $e->getMessage(),
             ]);
         } catch (TokenExpiredException $e) {
-            if ($this->shouldTrustAWorkingAccessToken() && $this->accessTokenStillWorks($verifier)) {
+            // Instagram and Threads extend their token in place and cannot
+            // renew it once expired, so a rejected extension means the
+            // connection is already doomed — say so while reconnecting still
+            // helps. Elsewhere a rejection often just means we lost a race.
+            if (! $this->account->platform->extendsAccessTokenOnRefresh()
+                && $this->accessTokenStillWorks($verifier)) {
                 return;
             }
 
@@ -75,53 +71,29 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
     }
 
     /**
-     * A rejected refresh does not on its own mean the connection is dead.
-     * X and Bluesky single-use their refresh_token — X issues a new one and
-     * invalidates the previous on every refresh, and refreshSession returns a
-     * mandatory new refreshJwt — so one a concurrent refresh already consumed
-     * is rejected while the current access_token keeps working. X is also
-     * documented by its own developer community to invalidate refresh_tokens
-     * spuriously. An account with no refresh_token at all fails here without
-     * any call being made at all. PublishToSocialPlatform hard-fails every post for a
-     * TokenExpired account, so disconnecting on a refresh rejection alone kills
-     * posts the access_token would still have published.
-     *
-     * This is the only place the (often billed) verify endpoint is reached from
-     * this job, and only after a refresh has already been rejected. A failure
-     * we can't attribute to the token — the platform being down, a network
-     * blip — leaves the account alone rather than disconnecting it on noise.
+     * The only place this job reaches the (billed) verify endpoint, and only
+     * once a refresh has been rejected — which on X and Bluesky usually means
+     * a concurrent refresh consumed the single-use refresh_token first.
      */
     private function accessTokenStillWorks(ConnectionVerifier $verifier): bool
     {
-        // A concurrent refresh may have persisted a new pair while ours was in
-        // flight, which is why ours was rejected. This instance still holds the
-        // token that was rotated away, so reload before judging it — otherwise
-        // the winner's healthy account gets disconnected.
         try {
-            // Inside the try: the account can be deleted mid-run, and this job
-            // has tries = 1, so an escaping ModelNotFoundException fails it.
+            // The winner of that race persisted a new pair; ours is stale.
             $this->account->refresh();
 
             if (! $verifier->verifyAccessToken($this->account)) {
                 return false;
             }
 
-            // This call is billed on X, and it proved the token alive just as
-            // well as a refresh would have. Record it so the pre-publish check
-            // does not pay to ask the same question minutes later.
             $this->recordVerification();
 
             return true;
         } catch (TokenExpiredException) {
             return false;
         } catch (PlatformUnavailableException|ConnectionException|ModelNotFoundException $e) {
-            // Only genuinely transient outcomes get the benefit of the doubt:
-            // the platform being down, the network dropping, or the account
-            // being deleted out from under a job that has tries = 1. Anything
-            // else — a decrypt failure after an APP_KEY rotation, an
-            // UnhandledMatchError from a newly added platform — would otherwise
-            // read as "the token is healthy" and leave the account Connected
-            // forever while every publish hard-fails.
+            // Only these three earn the benefit of the doubt. Reading any other
+            // failure as "healthy" leaves the account Connected forever while
+            // every publish hard-fails.
             Log::warning('Access token fallback check failed after a rejected refresh', [
                 'account_id' => $this->account->id,
                 'platform' => $this->account->platform->value,
@@ -133,32 +105,9 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
     }
 
     /**
-     * Whether a working access token is reason enough to stay connected after a
-     * refresh was rejected.
-     *
-     * It is for platforms that rotate a refresh_token, where a rejection often
-     * just means we lost a race and the current token is fine. It is not for
-     * Instagram and Threads: their long-lived token is extended in place and
-     * cannot be renewed once it expires, so a permanently rejected extension
-     * means the connection is already doomed. Staying connected because the
-     * token still reads would tell the owner only after it dies, when
-     * reconnecting is the only option left, and would keep retrying the
-     * rejected extension every 15 minutes across the whole 24-hour lead.
-     */
-    private function shouldTrustAWorkingAccessToken(): bool
-    {
-        return ! $this->account->platform->extendsAccessTokenOnRefresh();
-    }
-
-    /**
-     * Record the refresh as a verification, so the daily sweep and the
-     * pre-publish check can skip their own (often billed) verify call.
-     *
-     * refreshToken() reports whether one actually ran, so a lock skipped by a
-     * concurrent refresh never reaches here. Deliberately not
-     * done inside ConnectionVerifier::refreshToken() — refreshThenVerify()
-     * calls it and can still fail on the verify that follows, and a stamp
-     * written there would vouch for a credential nothing ever confirmed.
+     * Lets the daily sweep and the pre-publish check skip a verify of their
+     * own. Not done inside refreshToken(): refreshThenVerify() calls that too
+     * and can still fail on the verify that follows.
      */
     private function recordVerification(): void
     {

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -21,17 +21,21 @@ class RefreshSocialToken implements ShouldQueue
 
     public function __construct(public SocialAccount $account) {}
 
+    /**
+     * Refresh the token outright rather than verifying it first.
+     *
+     * A successful refresh already proves the credential is alive — the
+     * provider rejects a revoked one with a 4xx — so the verify endpoint adds
+     * nothing but cost. On X that endpoint is `GET /2/users/me`, billed as a
+     * "User: Read", and verifying a still-valid token left `token_expires_at`
+     * untouched: the account stayed inside RefreshExpiringTokens' window and
+     * was re-read every 15 minutes until the token actually died, which also
+     * left it expired for the stretch between expiry and the next tick.
+     */
     public function handle(ConnectionVerifier $verifier): void
     {
         try {
-            if ($this->account->platform->extendsAccessTokenOnRefresh()) {
-                // Instagram/Threads extend the long-lived token itself and
-                // can't be refreshed once expired, so extend it while it's
-                // still valid instead of waiting for it to fail.
-                $verifier->refreshToken($this->account);
-            } else {
-                $verifier->verify($this->account);
-            }
+            $verifier->refreshToken($this->account);
         } catch (PlatformUnavailableException $e) {
             Log::warning('Token refresh skipped: platform unavailable', [
                 'account_id' => $this->account->id,

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -43,6 +43,10 @@ class RefreshSocialToken implements ShouldQueue
                 'error' => $e->getMessage(),
             ]);
         } catch (TokenExpiredException $e) {
+            if ($this->accessTokenStillWorks($verifier)) {
+                return;
+            }
+
             $this->account->markAsTokenExpired($e->getMessage());
         } catch (Throwable $e) {
             Log::warning('Proactive token refresh failed', [
@@ -50,6 +54,37 @@ class RefreshSocialToken implements ShouldQueue
                 'platform' => $this->account->platform->value,
                 'error' => $e->getMessage(),
             ]);
+        }
+    }
+
+    /**
+     * A rejected refresh does not on its own mean the connection is dead.
+     * Providers that single-use their refresh_token (X, LinkedIn) reject one a
+     * concurrent refresh already consumed while the current access_token keeps
+     * working, and an account with no refresh_token at all fails here without
+     * any call being made. PublishToSocialPlatform hard-fails every post for a
+     * TokenExpired account, so disconnecting on a refresh rejection alone kills
+     * posts the access_token would still have published.
+     *
+     * This is the only place the (often billed) verify endpoint is reached from
+     * this job, and only after a refresh has already been rejected. A failure
+     * we can't attribute to the token — the platform being down, a network
+     * blip — leaves the account alone rather than disconnecting it on noise.
+     */
+    private function accessTokenStillWorks(ConnectionVerifier $verifier): bool
+    {
+        try {
+            return $verifier->verify($this->account);
+        } catch (TokenExpiredException) {
+            return false;
+        } catch (Throwable $e) {
+            Log::warning('Access token fallback check failed after a rejected refresh', [
+                'account_id' => $this->account->id,
+                'platform' => $this->account->platform->value,
+                'error' => $e->getMessage(),
+            ]);
+
+            return true;
         }
     }
 }

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -36,6 +36,7 @@ class RefreshSocialToken implements ShouldQueue
     {
         try {
             $verifier->refreshToken($this->account);
+            $this->recordVerification();
         } catch (PlatformUnavailableException $e) {
             Log::warning('Token refresh skipped: platform unavailable', [
                 'account_id' => $this->account->id,
@@ -74,7 +75,7 @@ class RefreshSocialToken implements ShouldQueue
     private function accessTokenStillWorks(ConnectionVerifier $verifier): bool
     {
         try {
-            return $verifier->verify($this->account);
+            return $verifier->verifyAccessToken($this->account);
         } catch (TokenExpiredException) {
             return false;
         } catch (Throwable $e) {
@@ -86,5 +87,30 @@ class RefreshSocialToken implements ShouldQueue
 
             return true;
         }
+    }
+
+    /**
+     * Record the refresh as a verification, so the daily sweep and the
+     * pre-publish check can skip their own (often billed) verify call.
+     *
+     * Only a refresh that actually happened proves anything, and only one that
+     * came back with a usable token: TokenRefreshClient classifies on HTTP
+     * status alone and never inspects the body, so a 200 carrying an empty
+     * token would otherwise be recorded as healthy. This is deliberately not
+     * done inside ConnectionVerifier::refreshToken() — refreshThenVerify()
+     * calls it and can still fail on the verify that follows, and a stamp
+     * written there would vouch for a credential nothing ever confirmed.
+     */
+    private function recordVerification(): void
+    {
+        if (! $this->account->platform->hasTokenRefreshFlow()) {
+            return;
+        }
+
+        if (blank($this->account->access_token)) {
+            return;
+        }
+
+        $this->account->update(['last_verified_at' => now()]);
     }
 }

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -49,16 +49,6 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
     {
         try {
             if ($verifier->refreshToken($this->account)) {
-                if (blank($this->account->access_token)) {
-                    // The refresh method stored whatever came back and pushed
-                    // token_expires_at forward, so the account would otherwise
-                    // leave the refresh window looking healthy while every
-                    // publish 401s on an empty token.
-                    $this->account->markAsTokenExpired('Token refresh returned an empty access token');
-
-                    return;
-                }
-
                 $this->recordVerification();
             }
         } catch (PlatformUnavailableException $e) {
@@ -146,17 +136,14 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
      * Record the refresh as a verification, so the daily sweep and the
      * pre-publish check can skip their own (often billed) verify call.
      *
-     * Deliberately not
+     * refreshToken() reports whether one actually ran, so a lock skipped by a
+     * concurrent refresh never reaches here. Deliberately not
      * done inside ConnectionVerifier::refreshToken() — refreshThenVerify()
      * calls it and can still fail on the verify that follows, and a stamp
      * written there would vouch for a credential nothing ever confirmed.
      */
     private function recordVerification(): void
     {
-        if (! $this->account->platform->hasTokenRefreshFlow()) {
-            return;
-        }
-
         $this->account->update(['last_verified_at' => now()]);
     }
 }

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -102,7 +102,16 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
             // has tries = 1, so an escaping ModelNotFoundException fails it.
             $this->account->refresh();
 
-            return $verifier->verifyAccessToken($this->account);
+            if (! $verifier->verifyAccessToken($this->account)) {
+                return false;
+            }
+
+            // This call is billed on X, and it proved the token alive just as
+            // well as a refresh would have. Record it so the pre-publish check
+            // does not pay to ask the same question minutes later.
+            $this->recordVerification();
+
+            return true;
         } catch (TokenExpiredException) {
             return false;
         } catch (PlatformUnavailableException|ConnectionException|ModelNotFoundException $e) {

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -8,18 +8,31 @@ use App\Exceptions\PlatformUnavailableException;
 use App\Exceptions\TokenExpiredException;
 use App\Models\SocialAccount;
 use App\Services\Social\ConnectionVerifier;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
-class RefreshSocialToken implements ShouldQueue
+class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
 {
     use Queueable;
 
     public int $tries = 1;
 
+    // Covers the full schedule cadence. RefreshExpiringTokens re-selects an
+    // account until its token_expires_at moves, which only happens once this
+    // job runs — so a backlogged queue would otherwise stack a job per tick,
+    // each rotating a single-use refresh_token again for nothing and widening
+    // the window where a worker death loses the pair.
+    public int $uniqueFor = 900;
+
     public function __construct(public SocialAccount $account) {}
+
+    public function uniqueId(): string
+    {
+        return $this->account->id;
+    }
 
     /**
      * Refresh the token outright rather than verifying it first.

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -59,15 +59,6 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
                 'platform' => $this->account->platform->value,
                 'error' => $e->getMessage(),
             ]);
-
-            // Transient failures are retried on the next tick, but only while
-            // there is still a live token to fall back on. Once it has expired
-            // and we still cannot renew it, the connection is dead in practice
-            // — say so, rather than retrying in silence until the owner finds
-            // out from a failed post.
-            if ($this->account->is_token_expired) {
-                $this->account->markAsTokenExpired($e->getMessage());
-            }
         } catch (TokenExpiredException $e) {
             if ($this->shouldTrustAWorkingAccessToken() && $this->accessTokenStillWorks($verifier)) {
                 return;

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -10,7 +10,9 @@ use App\Models\SocialAccount;
 use App\Services\Social\ConnectionVerifier;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
@@ -57,6 +59,15 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
                 'platform' => $this->account->platform->value,
                 'error' => $e->getMessage(),
             ]);
+
+            // Transient failures are retried on the next tick, but only while
+            // there is still a live token to fall back on. Once it has expired
+            // and we still cannot renew it, the connection is dead in practice
+            // — say so, rather than retrying in silence until the owner finds
+            // out from a failed post.
+            if ($this->account->is_token_expired) {
+                $this->account->markAsTokenExpired($e->getMessage());
+            }
         } catch (TokenExpiredException $e) {
             if ($this->shouldTrustAWorkingAccessToken() && $this->accessTokenStillWorks($verifier)) {
                 return;
@@ -103,7 +114,14 @@ class RefreshSocialToken implements ShouldBeUnique, ShouldQueue
             return $verifier->verifyAccessToken($this->account);
         } catch (TokenExpiredException) {
             return false;
-        } catch (Throwable $e) {
+        } catch (PlatformUnavailableException|ConnectionException|ModelNotFoundException $e) {
+            // Only genuinely transient outcomes get the benefit of the doubt:
+            // the platform being down, the network dropping, or the account
+            // being deleted out from under a job that has tries = 1. Anything
+            // else — a decrypt failure after an APP_KEY rotation, an
+            // UnhandledMatchError from a newly added platform — would otherwise
+            // read as "the token is healthy" and leave the account Connected
+            // forever while every publish hard-fails.
             Log::warning('Access token fallback check failed after a rejected refresh', [
                 'account_id' => $this->account->id,
                 'platform' => $this->account->platform->value,

--- a/app/Jobs/RefreshSocialToken.php
+++ b/app/Jobs/RefreshSocialToken.php
@@ -74,6 +74,12 @@ class RefreshSocialToken implements ShouldQueue
      */
     private function accessTokenStillWorks(ConnectionVerifier $verifier): bool
     {
+        // A concurrent refresh may have persisted a new pair while ours was in
+        // flight, which is why ours was rejected. This instance still holds the
+        // token that was rotated away, so reload before judging it — otherwise
+        // the winner's healthy account gets disconnected.
+        $this->account->refresh();
+
         try {
             return $verifier->verifyAccessToken($this->account);
         } catch (TokenExpiredException) {

--- a/app/Jobs/VerifyWorkspaceConnections.php
+++ b/app/Jobs/VerifyWorkspaceConnections.php
@@ -62,11 +62,6 @@ class VerifyWorkspaceConnections implements ShouldQueue
             }
 
             if ($this->verifyAccount($verifier, $account)) {
-                // If was TokenExpired but now verified OK, mark as connected again
-                if ($account->status === Status::TokenExpired) {
-                    $account->markAsConnected();
-                }
-
                 continue;
             }
 
@@ -95,6 +90,14 @@ class VerifyWorkspaceConnections implements ShouldQueue
         try {
             $verifier->verify($account);
             $account->update(['last_verified_at' => now()]);
+
+            // Promote here, not on this method's return value: it also returns
+            // true for "could not check, don't disconnect", and reviving an
+            // account on an outage tells the owner a reconnect worked when
+            // nothing was verified at all.
+            if ($account->status === Status::TokenExpired) {
+                $account->markAsConnected();
+            }
 
             return true;
         } catch (PlatformUnavailableException $e) {

--- a/app/Jobs/VerifyWorkspaceConnections.php
+++ b/app/Jobs/VerifyWorkspaceConnections.php
@@ -26,19 +26,10 @@ class VerifyWorkspaceConnections implements ShouldQueue
 
     public int $timeout = 120;
 
-    // How long a recorded verification (SocialAccount::last_verified_at) is
-    // trusted before this sweep re-checks the account. RefreshSocialToken
-    // stamps that field on every successful token refresh, and a refresh does
-    // more than the verify endpoint does: it replaces the access token rather
-    // than inspecting it, so there is nothing left for a billed read to
-    // confirm.
-    //
-    // For short-TTL platforms this means the sweep never calls verify() again
-    // — X and Bluesky tokens live 2h and are refreshed ~90 minutes apart, so
-    // the stamp is never stale at the daily tick. That is intended, not an
-    // oversight: the refresh detects a revoked or dead credential 16× more
-    // often than this sweep did, for free. What it cannot see (a suspended
-    // account whose refresh still succeeds) surfaces at publish time.
+    // A refresh stamps last_verified_at and replaces the access token, so
+    // there is nothing left for a billed read to confirm. On short-TTL
+    // platforms the stamp is never stale here and this sweep stops calling
+    // verify() entirely — intended, not an oversight.
     private const VERIFIED_WITHIN_HOURS = 12;
 
     public function __construct(public Workspace $workspace) {}
@@ -74,9 +65,8 @@ class VerifyWorkspaceConnections implements ShouldQueue
     }
 
     /**
-     * Only a Connected account can be skipped. A TokenExpired one still needs
-     * the call: verifying it is how it gets promoted back to Connected, so
-     * trusting a stale stamp would strand a recovered account forever.
+     * Connected only: verifying a TokenExpired account is how it gets promoted
+     * back, so a stale stamp would strand one that has recovered.
      */
     private function recentlyProvenValid(SocialAccount $account): bool
     {
@@ -91,10 +81,8 @@ class VerifyWorkspaceConnections implements ShouldQueue
             $verifier->verify($account);
             $account->update(['last_verified_at' => now()]);
 
-            // Promote here, not on this method's return value: it also returns
-            // true for "could not check, don't disconnect", and reviving an
-            // account on an outage tells the owner a reconnect worked when
-            // nothing was verified at all.
+            // Here, not on this method's return value — that is also true
+            // for "could not check, don't disconnect".
             if ($account->status === Status::TokenExpired) {
                 $account->markAsConnected();
             }

--- a/app/Jobs/VerifyWorkspaceConnections.php
+++ b/app/Jobs/VerifyWorkspaceConnections.php
@@ -28,9 +28,17 @@ class VerifyWorkspaceConnections implements ShouldQueue
 
     // How long a recorded verification (SocialAccount::last_verified_at) is
     // trusted before this sweep re-checks the account. RefreshSocialToken
-    // stamps that field on every successful token refresh, and a refresh
-    // proves the credential just as well as the verify endpoint does — without
-    // the per-call charge providers like X bill for reading a profile.
+    // stamps that field on every successful token refresh, and a refresh does
+    // more than the verify endpoint does: it replaces the access token rather
+    // than inspecting it, so there is nothing left for a billed read to
+    // confirm.
+    //
+    // For short-TTL platforms this means the sweep never calls verify() again
+    // — X and Bluesky tokens live 2h and are refreshed ~90 minutes apart, so
+    // the stamp is never stale at the daily tick. That is intended, not an
+    // oversight: the refresh detects a revoked or dead credential 16× more
+    // often than this sweep did, for free. What it cannot see (a suspended
+    // account whose refresh still succeeds) surfaces at publish time.
     private const VERIFIED_WITHIN_HOURS = 12;
 
     public function __construct(public Workspace $workspace) {}

--- a/app/Jobs/VerifyWorkspaceConnections.php
+++ b/app/Jobs/VerifyWorkspaceConnections.php
@@ -86,6 +86,7 @@ class VerifyWorkspaceConnections implements ShouldQueue
     {
         try {
             $verifier->verify($account);
+            $account->update(['last_verified_at' => now()]);
 
             return true;
         } catch (PlatformUnavailableException $e) {

--- a/app/Jobs/VerifyWorkspaceConnections.php
+++ b/app/Jobs/VerifyWorkspaceConnections.php
@@ -26,6 +26,13 @@ class VerifyWorkspaceConnections implements ShouldQueue
 
     public int $timeout = 120;
 
+    // How long a recorded verification (SocialAccount::last_verified_at) is
+    // trusted before this sweep re-checks the account. RefreshSocialToken
+    // stamps that field on every successful token refresh, and a refresh
+    // proves the credential just as well as the verify endpoint does — without
+    // the per-call charge providers like X bill for reading a profile.
+    private const VERIFIED_WITHIN_HOURS = 12;
+
     public function __construct(public Workspace $workspace) {}
 
     public function handle(ConnectionVerifier $verifier): void
@@ -42,6 +49,10 @@ class VerifyWorkspaceConnections implements ShouldQueue
         $disconnectedAccounts = collect();
 
         foreach ($accounts as $account) {
+            if ($this->recentlyProvenValid($account)) {
+                continue;
+            }
+
             if ($this->verifyAccount($verifier, $account)) {
                 // If was TokenExpired but now verified OK, mark as connected again
                 if ($account->status === Status::TokenExpired) {
@@ -57,6 +68,18 @@ class VerifyWorkspaceConnections implements ShouldQueue
         if ($disconnectedAccounts->isNotEmpty()) {
             $this->notifyOwner($disconnectedAccounts);
         }
+    }
+
+    /**
+     * Only a Connected account can be skipped. A TokenExpired one still needs
+     * the call: verifying it is how it gets promoted back to Connected, so
+     * trusting a stale stamp would strand a recovered account forever.
+     */
+    private function recentlyProvenValid(SocialAccount $account): bool
+    {
+        return $account->status === Status::Connected
+            && $account->last_verified_at !== null
+            && $account->last_verified_at->isAfter(now()->subHours(self::VERIFIED_WITHIN_HOURS));
     }
 
     private function verifyAccount(ConnectionVerifier $verifier, SocialAccount $account): bool

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -26,6 +26,22 @@ use Illuminate\Support\Facades\Http;
 class ConnectionVerifier
 {
     /**
+     * How long the per-account refresh lock survives without being released.
+     *
+     * It has to outlast the slowest refresh a provider can make us wait for,
+     * or the lock lapses mid-flight and a second process refreshes with the
+     * same single-use refresh_token — leaving one of the two rejected. The
+     * ceiling is Bluesky, which refreshes with two sequential calls
+     * (refreshSession, then the createSession re-auth), each bounded by the
+     * HTTP client's connect and read timeouts.
+     *
+     * The lock is released in a finally block, so this only governs how long a
+     * worker that died mid-refresh blocks the next attempt — and the next
+     * scheduler tick is 15 minutes out either way.
+     */
+    public const REFRESH_LOCK_SECONDS = 120;
+
+    /**
      * Verify that a social account connection is still valid.
      *
      * @throws TokenExpiredException if the connection is invalid
@@ -150,7 +166,7 @@ class ConnectionVerifier
      */
     public function refreshToken(SocialAccount $account): bool
     {
-        $lock = Cache::lock("token_refresh:{$account->id}", 30);
+        $lock = Cache::lock("token_refresh:{$account->id}", self::REFRESH_LOCK_SECONDS);
 
         if (! $lock->get()) {
             // Another process is already refreshing this token

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -29,12 +29,15 @@ class ConnectionVerifier
     /**
      * Read and connect timeouts for a token refresh.
      *
-     * Deliberately generous. refreshHttp() is shared with the ~24 publish and
-     * analytics call sites, and for X, Bluesky and TikTok the refresh_token is
-     * single-use: giving up on a request the provider has already processed
-     * loses the rotated pair for good and costs the user a manual reconnect.
-     * A token endpoint answers in milliseconds, so a long ceiling is nearly
-     * free, while a tight one turns provider slowness into dead accounts.
+     * These match the HTTP client's own defaults, and are stated here so a
+     * future change to those defaults cannot silently break the lock invariant
+     * below. They are deliberately generous: refreshToken() is reached from
+     * ~24 publish and analytics call sites as well as the scheduled job, and
+     * for X, Bluesky and TikTok the refresh_token is single-use, so abandoning
+     * a request the provider has already processed loses the rotated pair for
+     * good and costs the user a manual reconnect. A token endpoint answers in
+     * milliseconds, so a long ceiling is nearly free while a tight one turns
+     * provider slowness into dead accounts.
      */
     public const REFRESH_TIMEOUT_SECONDS = 30;
 

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -152,6 +152,14 @@ class ConnectionVerifier
                 // Mastodon tokens don't expire either.
                 default => null,
             };
+
+            // A provider that hands back a fresh token has just confirmed the
+            // credential, so record it as a verification: jobs that would
+            // otherwise call the (often billed) verify endpoint can trust this
+            // instead. Platforms with nothing to refresh prove nothing here.
+            if ($account->platform->hasTokenRefreshFlow()) {
+                $account->update(['last_verified_at' => now()]);
+            }
         } finally {
             $lock->release();
         }

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -141,10 +141,14 @@ class ConnectionVerifier
      * use verify() instead. This method always attempts a refresh under
      * the per-account lock.
      *
+     * @return bool whether a refresh actually ran. False means another process
+     *              already held the lock and this call did nothing, so callers
+     *              must not treat it as having proven anything.
+     *
      * @throws TokenExpiredException if refresh is rejected by the provider (4xx)
      * @throws PlatformUnavailableException if the platform is unreachable (5xx / network)
      */
-    public function refreshToken(SocialAccount $account): void
+    public function refreshToken(SocialAccount $account): bool
     {
         $lock = Cache::lock("token_refresh:{$account->id}", 30);
 
@@ -152,7 +156,7 @@ class ConnectionVerifier
             // Another process is already refreshing this token
             $account->refresh();
 
-            return;
+            return false;
         }
 
         try {
@@ -169,6 +173,8 @@ class ConnectionVerifier
                 // Mastodon tokens don't expire either.
                 default => null,
             };
+
+            return true;
         } finally {
             $lock->release();
         }

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -29,26 +29,28 @@ class ConnectionVerifier
     /**
      * Read and connect timeouts for a token refresh.
      *
-     * Bounding the call ourselves is what keeps a refresh under the lock that
-     * protects it. The HTTP client's defaults (30s read, 10s connect) let a
-     * single Bluesky refresh — two sequential calls — run for ~80 seconds under
-     * a 30-second lock, so the lock could lapse mid-flight and let a second
-     * process refresh with the same single-use refresh_token.
-     *
-     * Fixing that by holding the lock longer would have been worse: publishers
-     * wait on the same lock, and a lock left behind by a worker that died
-     * mid-refresh makes them fall through and publish with an expired token.
-     * A token endpoint answers in milliseconds, so bounding the call is free.
+     * Deliberately generous. refreshHttp() is shared with the ~24 publish and
+     * analytics call sites, and for X, Bluesky and TikTok the refresh_token is
+     * single-use: giving up on a request the provider has already processed
+     * loses the rotated pair for good and costs the user a manual reconnect.
+     * A token endpoint answers in milliseconds, so a long ceiling is nearly
+     * free, while a tight one turns provider slowness into dead accounts.
      */
-    public const REFRESH_TIMEOUT_SECONDS = 8;
+    public const REFRESH_TIMEOUT_SECONDS = 30;
 
-    public const REFRESH_CONNECT_TIMEOUT_SECONDS = 4;
+    public const REFRESH_CONNECT_TIMEOUT_SECONDS = 10;
 
     /**
      * Must exceed the slowest refresh the timeouts above allow — Bluesky's two
-     * sequential calls. Pinned by a test so the two can't drift apart.
+     * sequential calls — or the lock lapses mid-flight and a second process
+     * refreshes with the same single-use refresh_token. Pinned by a test.
+     *
+     * The cost of erring long is that a worker dying mid-refresh leaves the
+     * lock held for this many seconds, during which a publish falls through to
+     * an expired token and retries. That is recoverable; an abandoned rotation
+     * is not.
      */
-    public const REFRESH_LOCK_SECONDS = 30;
+    public const REFRESH_LOCK_SECONDS = 120;
 
     /**
      * Verify that a social account connection is still valid.
@@ -120,6 +122,33 @@ class ConnectionVerifier
 
             throw $original ?? $e;
         }
+    }
+
+    /**
+     * Pull a token out of a refresh response, refusing to persist a blank one.
+     *
+     * TokenRefreshClient classifies on HTTP status alone and never inspects the
+     * body, so a 200 carrying no token would otherwise be written straight over
+     * a credential that still works — and on Instagram and Threads, where the
+     * refresh_token is set to the same value, both halves go at once. Treat it
+     * as the platform misbehaving: the stored pair stays put and the next tick
+     * retries, instead of the account needing a manual reconnect.
+     *
+     * @param  array<string, mixed>|null  $data
+     *
+     * @throws PlatformUnavailableException
+     */
+    private function tokenFrom(?array $data, Platform $platform, string $key = 'access_token'): string
+    {
+        $token = data_get($data, $key);
+
+        if (blank($token)) {
+            throw new PlatformUnavailableException(
+                "{$platform->label()} returned a successful refresh with no {$key}."
+            );
+        }
+
+        return (string) $token;
     }
 
     private function refreshHttp(): PendingRequest
@@ -233,7 +262,7 @@ class ConnectionVerifier
         $data = $response->json();
 
         $account->update([
-            'access_token' => data_get($data, 'access_token'),
+            'access_token' => $this->tokenFrom($data, $account->platform),
             'refresh_token' => data_get($data, 'refresh_token', $account->refresh_token),
             'token_expires_at' => data_get($data, 'expires_in') ? now()->addSeconds(data_get($data, 'expires_in')) : null,
         ]);
@@ -257,7 +286,7 @@ class ConnectionVerifier
         $data = $response->json();
 
         $account->update([
-            'access_token' => data_get($data, 'access_token'),
+            'access_token' => $this->tokenFrom($data, $account->platform),
             'refresh_token' => data_get($data, 'refresh_token', $account->refresh_token),
             'token_expires_at' => now()->addSeconds(data_get($data, 'expires_in', $account->platform->defaultTokenTtlSeconds())),
         ]);
@@ -276,8 +305,8 @@ class ConnectionVerifier
 
             $data = $response->json();
             $account->update([
-                'access_token' => data_get($data, 'accessJwt'),
-                'refresh_token' => data_get($data, 'refreshJwt'),
+                'access_token' => $this->tokenFrom($data, $account->platform, 'accessJwt'),
+                'refresh_token' => $this->tokenFrom($data, $account->platform, 'refreshJwt'),
                 'token_expires_at' => now()->addHours(2),
             ]);
 
@@ -297,8 +326,8 @@ class ConnectionVerifier
 
                 $data = $reauth->json();
                 $account->update([
-                    'access_token' => data_get($data, 'accessJwt'),
-                    'refresh_token' => data_get($data, 'refreshJwt'),
+                    'access_token' => $this->tokenFrom($data, $account->platform, 'accessJwt'),
+                    'refresh_token' => $this->tokenFrom($data, $account->platform, 'refreshJwt'),
                     'token_expires_at' => now()->addHours(2),
                 ]);
 
@@ -330,7 +359,7 @@ class ConnectionVerifier
         $data = $response->json();
 
         $account->update([
-            'access_token' => data_get($data, 'access_token'),
+            'access_token' => $this->tokenFrom($data, $account->platform),
             'token_expires_at' => data_get($data, 'expires_in') ? now()->addSeconds(data_get($data, 'expires_in')) : null,
         ]);
 
@@ -354,7 +383,7 @@ class ConnectionVerifier
         $data = $response->json();
 
         $account->update([
-            'access_token' => data_get($data, 'access_token'),
+            'access_token' => $this->tokenFrom($data, $account->platform),
             'refresh_token' => data_get($data, 'refresh_token', $account->refresh_token),
             'token_expires_at' => data_get($data, 'expires_in') ? now()->addSeconds(data_get($data, 'expires_in')) : null,
         ]);
@@ -381,7 +410,7 @@ class ConnectionVerifier
         $data = $response->json();
 
         $account->update([
-            'access_token' => data_get($data, 'access_token'),
+            'access_token' => $this->tokenFrom($data, $account->platform),
             'refresh_token' => data_get($data, 'refresh_token', $account->refresh_token),
             'token_expires_at' => data_get($data, 'expires_in') ? now()->addSeconds(data_get($data, 'expires_in')) : null,
         ]);
@@ -401,7 +430,7 @@ class ConnectionVerifier
         );
 
         $data = $response->json();
-        $newToken = data_get($data, 'access_token');
+        $newToken = $this->tokenFrom($data, $account->platform);
 
         $account->update([
             'access_token' => $newToken,
@@ -423,7 +452,7 @@ class ConnectionVerifier
         );
 
         $data = $response->json();
-        $newToken = data_get($data, 'access_token');
+        $newToken = $this->tokenFrom($data, $account->platform);
 
         $account->update([
             'access_token' => $newToken,

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -97,6 +97,23 @@ class ConnectionVerifier
     }
 
     /**
+     * Check the stored access token exactly as it is, skipping the
+     * refresh-and-retry ladder verify() runs.
+     *
+     * Callers that have just had a refresh rejected need this: routing through
+     * verify() would re-send the refresh_token the provider only just rejected,
+     * and on Bluesky re-run the password re-auth AT Proto rate-limits per
+     * account.
+     *
+     * @throws TokenExpiredException if the access token itself is rejected
+     * @throws PlatformUnavailableException if the platform is unreachable
+     */
+    public function verifyAccessToken(SocialAccount $account): bool
+    {
+        return $this->callVerifyEndpoint($account);
+    }
+
+    /**
      * @throws TokenExpiredException
      */
     private function callVerifyEndpoint(SocialAccount $account): bool
@@ -152,14 +169,6 @@ class ConnectionVerifier
                 // Mastodon tokens don't expire either.
                 default => null,
             };
-
-            // A provider that hands back a fresh token has just confirmed the
-            // credential, so record it as a verification: jobs that would
-            // otherwise call the (often billed) verify endpoint can trust this
-            // instead. Platforms with nothing to refresh prove nothing here.
-            if ($account->platform->hasTokenRefreshFlow()) {
-                $account->update(['last_verified_at' => now()]);
-            }
         } finally {
             $lock->release();
         }

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -145,9 +145,10 @@ class ConnectionVerifier
     {
         $token = data_get($data, $key);
 
-        // data_get() only falls back when the key is absent, so an explicit
-        // null overwrites. Providers that omit the field mean "keep using the
-        // one you have", and so does one that answers with nothing.
+        // Blank, not just missing: data_get()'s own default would let an
+        // explicit null through and overwrite. A provider that omits the field
+        // means "keep using the one you have", and so does one that sends it
+        // empty.
         return blank($token) ? $current : (string) $token;
     }
 

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -141,6 +141,16 @@ class ConnectionVerifier
      *
      * @throws PlatformUnavailableException
      */
+    private function rotatedTokenFrom(?array $data, string $key, string $current): string
+    {
+        $token = data_get($data, $key);
+
+        // data_get() only falls back when the key is absent, so an explicit
+        // null overwrites. Providers that omit the field mean "keep using the
+        // one you have", and so does one that answers with nothing.
+        return blank($token) ? $current : (string) $token;
+    }
+
     private function tokenFrom(?array $data, Platform $platform, string $key = 'access_token'): string
     {
         $token = data_get($data, $key);
@@ -217,8 +227,19 @@ class ConnectionVerifier
         $lock = Cache::lock("token_refresh:{$account->id}", self::REFRESH_LOCK_SECONDS);
 
         if (! $lock->get()) {
-            // Another process is already refreshing this token
+            // Another process is already refreshing this token.
             $account->refresh();
+
+            if ($account->is_token_expired) {
+                // Reporting "nothing refreshed" would hand the caller a token
+                // it already knows is dead. A publisher posts with it, takes a
+                // 401, and PublishToSocialPlatform finalises the post as failed
+                // and disconnects the account — over a lock a dying worker left
+                // behind. Transient is the truth here: try again shortly.
+                throw new PlatformUnavailableException(
+                    "A {$account->platform->label()} token refresh is already in progress."
+                );
+            }
 
             return false;
         }
@@ -266,7 +287,7 @@ class ConnectionVerifier
 
         $account->update([
             'access_token' => $this->tokenFrom($data, $account->platform),
-            'refresh_token' => data_get($data, 'refresh_token', $account->refresh_token),
+            'refresh_token' => $this->rotatedTokenFrom($data, 'refresh_token', $account->refresh_token),
             'token_expires_at' => data_get($data, 'expires_in') ? now()->addSeconds(data_get($data, 'expires_in')) : null,
         ]);
 
@@ -290,7 +311,7 @@ class ConnectionVerifier
 
         $account->update([
             'access_token' => $this->tokenFrom($data, $account->platform),
-            'refresh_token' => data_get($data, 'refresh_token', $account->refresh_token),
+            'refresh_token' => $this->rotatedTokenFrom($data, 'refresh_token', $account->refresh_token),
             'token_expires_at' => now()->addSeconds(data_get($data, 'expires_in', $account->platform->defaultTokenTtlSeconds())),
         ]);
 
@@ -387,7 +408,7 @@ class ConnectionVerifier
 
         $account->update([
             'access_token' => $this->tokenFrom($data, $account->platform),
-            'refresh_token' => data_get($data, 'refresh_token', $account->refresh_token),
+            'refresh_token' => $this->rotatedTokenFrom($data, 'refresh_token', $account->refresh_token),
             'token_expires_at' => data_get($data, 'expires_in') ? now()->addSeconds(data_get($data, 'expires_in')) : null,
         ]);
 
@@ -414,7 +435,7 @@ class ConnectionVerifier
 
         $account->update([
             'access_token' => $this->tokenFrom($data, $account->platform),
-            'refresh_token' => data_get($data, 'refresh_token', $account->refresh_token),
+            'refresh_token' => $this->rotatedTokenFrom($data, 'refresh_token', $account->refresh_token),
             'token_expires_at' => data_get($data, 'expires_in') ? now()->addSeconds(data_get($data, 'expires_in')) : null,
         ]);
 

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -27,17 +27,11 @@ use Illuminate\Support\Facades\Http;
 class ConnectionVerifier
 {
     /**
-     * Read and connect timeouts for a token refresh.
-     *
-     * These match the HTTP client's own defaults, and are stated here so a
-     * future change to those defaults cannot silently break the lock invariant
-     * below. They are deliberately generous: refreshToken() is reached from
-     * ~24 publish and analytics call sites as well as the scheduled job, and
-     * for X, Bluesky and TikTok the refresh_token is single-use, so abandoning
-     * a request the provider has already processed loses the rotated pair for
-     * good and costs the user a manual reconnect. A token endpoint answers in
-     * milliseconds, so a long ceiling is nearly free while a tight one turns
-     * provider slowness into dead accounts.
+     * Read and connect timeouts for a token refresh. Stated explicitly, even
+     * though they match the client's defaults, so a change to those cannot
+     * silently break the lock invariant below. Generous on purpose: giving up
+     * on a request the provider already processed loses a single-use
+     * refresh_token for good.
      */
     public const REFRESH_TIMEOUT_SECONDS = 30;
 
@@ -46,12 +40,7 @@ class ConnectionVerifier
     /**
      * Must exceed the slowest refresh the timeouts above allow — Bluesky's two
      * sequential calls — or the lock lapses mid-flight and a second process
-     * refreshes with the same single-use refresh_token. Pinned by a test.
-     *
-     * The cost of erring long is that a worker dying mid-refresh leaves the
-     * lock held for this many seconds, during which a publish falls through to
-     * an expired token and retries. That is recoverable; an abandoned rotation
-     * is not.
+     * reuses the same single-use refresh_token. Pinned by a test.
      */
     public const REFRESH_LOCK_SECONDS = 120;
 
@@ -66,11 +55,9 @@ class ConnectionVerifier
         // Hard-expired tokens cannot make API calls — refresh is mandatory.
         // For tokens that are still valid OR only "expiring soon", try the
         // verify endpoint FIRST with the current access_token. This avoids
-        // rotating refresh_tokens unnecessarily — X and Bluesky invalidate the
-        // previous refresh_token on each refresh, so refreshing during races
-        // causes false-positive disconnects even though the access_token still
-        // works fine. (LinkedIn does not: it returns the same refresh_token,
-        // keeping the TTL from the original authorization.)
+        // rotating refresh_tokens unnecessarily — X and Bluesky single-use
+        // theirs, so refreshing during a race disconnects an account whose
+        // access_token still works. (LinkedIn returns the same token.)
         if ($account->is_token_expired) {
             return $this->refreshThenVerify($account);
         }
@@ -130,12 +117,8 @@ class ConnectionVerifier
     /**
      * Pull a token out of a refresh response, refusing to persist a blank one.
      *
-     * TokenRefreshClient classifies on HTTP status alone and never inspects the
-     * body, so a 200 carrying no token would otherwise be written straight over
-     * a credential that still works — and on Instagram and Threads, where the
-     * refresh_token is set to the same value, both halves go at once. Treat it
-     * as the platform misbehaving: the stored pair stays put and the next tick
-     * retries, instead of the account needing a manual reconnect.
+     * TokenRefreshClient classifies on HTTP status alone, so a 200 carrying no
+     * token would otherwise overwrite a credential that still works.
      *
      * @param  array<string, mixed>|null  $data
      *
@@ -145,10 +128,8 @@ class ConnectionVerifier
     {
         $token = data_get($data, $key);
 
-        // Blank, not just missing: data_get()'s own default would let an
-        // explicit null through and overwrite. A provider that omits the field
-        // means "keep using the one you have", and so does one that sends it
-        // empty.
+        // Blank, not just missing: data_get()'s own default lets an explicit
+        // null through and overwrite.
         return blank($token) ? $current : (string) $token;
     }
 
@@ -172,13 +153,9 @@ class ConnectionVerifier
     }
 
     /**
-     * Check the stored access token exactly as it is, skipping the
-     * refresh-and-retry ladder verify() runs.
-     *
-     * Callers that have just had a refresh rejected need this: routing through
-     * verify() would re-send the refresh_token the provider only just rejected,
-     * and on Bluesky re-run the password re-auth AT Proto rate-limits per
-     * account.
+     * Check the stored access token as it is, skipping the refresh-and-retry
+     * ladder verify() runs — which would re-send a refresh_token the provider
+     * just rejected, and on Bluesky re-run a rate-limited password re-auth.
      *
      * @throws TokenExpiredException if the access token itself is rejected
      * @throws PlatformUnavailableException if the platform is unreachable
@@ -216,9 +193,8 @@ class ConnectionVerifier
      * use verify() instead. This method always attempts a refresh under
      * the per-account lock.
      *
-     * @return bool whether a refresh actually ran. False means another process
-     *              already held the lock and this call did nothing, so callers
-     *              must not treat it as having proven anything.
+     * @return bool whether a refresh actually ran — false means another
+     *              process held the lock and this call proved nothing.
      *
      * @throws TokenExpiredException if refresh is rejected by the provider (4xx)
      * @throws PlatformUnavailableException if the platform is unreachable (5xx / network)
@@ -232,11 +208,9 @@ class ConnectionVerifier
             $account->refresh();
 
             if ($account->is_token_expired) {
-                // Reporting "nothing refreshed" would hand the caller a token
-                // it already knows is dead. A publisher posts with it, takes a
-                // 401, and PublishToSocialPlatform finalises the post as failed
-                // and disconnects the account — over a lock a dying worker left
-                // behind. Transient is the truth here: try again shortly.
+                // Returning false would hand the caller a token it knows is
+                // dead; a publisher then posts with it, fails the post and
+                // disconnects the account. Transient is the truth here.
                 throw new PlatformUnavailableException(
                     "A {$account->platform->label()} token refresh is already in progress."
                 );
@@ -247,9 +221,8 @@ class ConnectionVerifier
 
         try {
             if (! $account->platform->hasTokenRefreshFlow()) {
-                // Facebook / InstagramFacebook use Page tokens that don't
-                // expire, Mastodon's don't either, and Telegram and Discord
-                // share one bot token with nothing per-account to refresh.
+                // Page tokens, Mastodon and the shared bot tokens have
+                // nothing per-account to refresh.
                 return false;
             }
 

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -20,26 +20,35 @@ use App\Models\SocialAccount;
 use App\Services\Social\Discord\DiscordClient;
 use App\Services\Social\Meta\GraphError;
 use App\Services\Social\Telegram\TelegramApi;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
 class ConnectionVerifier
 {
     /**
-     * How long the per-account refresh lock survives without being released.
+     * Read and connect timeouts for a token refresh.
      *
-     * It has to outlast the slowest refresh a provider can make us wait for,
-     * or the lock lapses mid-flight and a second process refreshes with the
-     * same single-use refresh_token — leaving one of the two rejected. The
-     * ceiling is Bluesky, which refreshes with two sequential calls
-     * (refreshSession, then the createSession re-auth), each bounded by the
-     * HTTP client's connect and read timeouts.
+     * Bounding the call ourselves is what keeps a refresh under the lock that
+     * protects it. The HTTP client's defaults (30s read, 10s connect) let a
+     * single Bluesky refresh — two sequential calls — run for ~80 seconds under
+     * a 30-second lock, so the lock could lapse mid-flight and let a second
+     * process refresh with the same single-use refresh_token.
      *
-     * The lock is released in a finally block, so this only governs how long a
-     * worker that died mid-refresh blocks the next attempt — and the next
-     * scheduler tick is 15 minutes out either way.
+     * Fixing that by holding the lock longer would have been worse: publishers
+     * wait on the same lock, and a lock left behind by a worker that died
+     * mid-refresh makes them fall through and publish with an expired token.
+     * A token endpoint answers in milliseconds, so bounding the call is free.
      */
-    public const REFRESH_LOCK_SECONDS = 120;
+    public const REFRESH_TIMEOUT_SECONDS = 8;
+
+    public const REFRESH_CONNECT_TIMEOUT_SECONDS = 4;
+
+    /**
+     * Must exceed the slowest refresh the timeouts above allow — Bluesky's two
+     * sequential calls. Pinned by a test so the two can't drift apart.
+     */
+    public const REFRESH_LOCK_SECONDS = 30;
 
     /**
      * Verify that a social account connection is still valid.
@@ -113,6 +122,12 @@ class ConnectionVerifier
         }
     }
 
+    private function refreshHttp(): PendingRequest
+    {
+        return Http::timeout(self::REFRESH_TIMEOUT_SECONDS)
+            ->connectTimeout(self::REFRESH_CONNECT_TIMEOUT_SECONDS);
+    }
+
     /**
      * Check the stored access token exactly as it is, skipping the
      * refresh-and-retry ladder verify() runs.
@@ -177,6 +192,13 @@ class ConnectionVerifier
         }
 
         try {
+            if (! $account->platform->hasTokenRefreshFlow()) {
+                // Facebook / InstagramFacebook use Page tokens that don't
+                // expire, Mastodon's don't either, and Telegram and Discord
+                // share one bot token with nothing per-account to refresh.
+                return false;
+            }
+
             match ($account->platform) {
                 Platform::LinkedIn, Platform::LinkedInPage => $this->refreshLinkedInToken($account),
                 Platform::X => $this->refreshXToken($account),
@@ -186,9 +208,6 @@ class ConnectionVerifier
                 Platform::Pinterest => $this->refreshPinterestToken($account),
                 Platform::Threads => $this->refreshThreadsToken($account),
                 Platform::Instagram => $this->refreshInstagramToken($account),
-                // Facebook / InstagramFacebook use Page tokens that don't expire.
-                // Mastodon tokens don't expire either.
-                default => null,
             };
 
             return true;
@@ -203,7 +222,7 @@ class ConnectionVerifier
             throw new TokenExpiredException("No refresh token available for {$account->platform->label()} account");
         }
 
-        $response = TokenRefreshClient::for($account->platform)->send(fn () => Http::asForm()
+        $response = TokenRefreshClient::for($account->platform)->send(fn () => $this->refreshHttp()->asForm()
             ->post(config('trypost.platforms.linkedin.oauth_api').'/oauth/v2/accessToken', [
                 'grant_type' => 'refresh_token',
                 'refresh_token' => $account->refresh_token,
@@ -228,7 +247,7 @@ class ConnectionVerifier
             throw new TokenExpiredException('No refresh token available for X account');
         }
 
-        $response = TokenRefreshClient::for(Platform::X)->send(fn () => Http::asForm()
+        $response = TokenRefreshClient::for(Platform::X)->send(fn () => $this->refreshHttp()->asForm()
             ->withBasicAuth(config('services.x.client_id'), config('services.x.client_secret'))
             ->post(config('trypost.platforms.x.api').'/oauth2/token', [
                 'grant_type' => 'refresh_token',
@@ -252,7 +271,7 @@ class ConnectionVerifier
         $client = TokenRefreshClient::for(Platform::Bluesky);
 
         try {
-            $response = $client->send(fn () => Http::withToken($account->refresh_token)
+            $response = $client->send(fn () => $this->refreshHttp()->withToken($account->refresh_token)
                 ->post("{$service}/xrpc/".BlueskyLexicon::REFRESH_SESSION));
 
             $data = $response->json();
@@ -271,7 +290,7 @@ class ConnectionVerifier
 
         if (isset($account->meta['password'])) {
             try {
-                $reauth = $client->send(fn () => Http::post("{$service}/xrpc/".BlueskyLexicon::CREATE_SESSION, [
+                $reauth = $client->send(fn () => $this->refreshHttp()->post("{$service}/xrpc/".BlueskyLexicon::CREATE_SESSION, [
                     'identifier' => $account->meta['identifier'],
                     'password' => decrypt($account->meta['password']),
                 ]));
@@ -300,7 +319,7 @@ class ConnectionVerifier
             throw new TokenExpiredException('No refresh token available for YouTube account');
         }
 
-        $response = TokenRefreshClient::for(Platform::YouTube)->send(fn () => Http::asForm()
+        $response = TokenRefreshClient::for(Platform::YouTube)->send(fn () => $this->refreshHttp()->asForm()
             ->post(config('trypost.platforms.youtube.oauth_api').'/token', [
                 'grant_type' => 'refresh_token',
                 'refresh_token' => $account->refresh_token,
@@ -324,7 +343,7 @@ class ConnectionVerifier
             throw new TokenExpiredException('No refresh token available for TikTok account');
         }
 
-        $response = TokenRefreshClient::for(Platform::TikTok)->send(fn () => Http::asForm()
+        $response = TokenRefreshClient::for(Platform::TikTok)->send(fn () => $this->refreshHttp()->asForm()
             ->post(config('trypost.platforms.tiktok.api').'/oauth/token/', [
                 'grant_type' => 'refresh_token',
                 'refresh_token' => $account->refresh_token,
@@ -351,7 +370,7 @@ class ConnectionVerifier
 
         $credentials = base64_encode(config('services.pinterest.client_id').':'.config('services.pinterest.client_secret'));
 
-        $response = TokenRefreshClient::for(Platform::Pinterest)->send(fn () => Http::withHeaders([
+        $response = TokenRefreshClient::for(Platform::Pinterest)->send(fn () => $this->refreshHttp()->withHeaders([
             'Authorization' => "Basic {$credentials}",
             'Content-Type' => 'application/x-www-form-urlencoded',
         ])->asForm()->post(config('trypost.platforms.pinterest.api').'/oauth/token', [
@@ -374,7 +393,7 @@ class ConnectionVerifier
     {
         // Threads uses long-lived tokens that can be refreshed
         $response = TokenRefreshClient::for(Platform::Threads)->send(
-            fn () => Http::get(config('trypost.platforms.threads.auth_api').'/refresh_access_token', [
+            fn () => $this->refreshHttp()->get(config('trypost.platforms.threads.auth_api').'/refresh_access_token', [
                 'grant_type' => 'th_refresh_token',
                 'access_token' => $account->access_token,
             ]),
@@ -396,7 +415,7 @@ class ConnectionVerifier
     private function refreshInstagramToken(SocialAccount $account): void
     {
         $response = TokenRefreshClient::for(Platform::Instagram)->send(
-            fn () => Http::get(config('trypost.platforms.instagram.auth_api').'/refresh_access_token', [
+            fn () => $this->refreshHttp()->get(config('trypost.platforms.instagram.auth_api').'/refresh_access_token', [
                 'grant_type' => 'ig_refresh_token',
                 'access_token' => $account->access_token,
             ]),

--- a/app/Services/Social/ConnectionVerifier.php
+++ b/app/Services/Social/ConnectionVerifier.php
@@ -52,10 +52,11 @@ class ConnectionVerifier
         // Hard-expired tokens cannot make API calls — refresh is mandatory.
         // For tokens that are still valid OR only "expiring soon", try the
         // verify endpoint FIRST with the current access_token. This avoids
-        // rotating refresh_tokens unnecessarily — many providers (X v2,
-        // LinkedIn, etc.) invalidate the previous refresh_token on each
-        // refresh, so proactive refreshes during races cause false-positive
-        // disconnects even though the access_token still works fine.
+        // rotating refresh_tokens unnecessarily — X and Bluesky invalidate the
+        // previous refresh_token on each refresh, so refreshing during races
+        // causes false-positive disconnects even though the access_token still
+        // works fine. (LinkedIn does not: it returns the same refresh_token,
+        // keeping the TTL from the original authorization.)
         if ($account->is_token_expired) {
             return $this->refreshThenVerify($account);
         }

--- a/app/Services/Social/XAnalytics.php
+++ b/app/Services/Social/XAnalytics.php
@@ -16,10 +16,7 @@ class XAnalytics
 {
     use HasSocialHttpClient;
 
-    /**
-     * Each page is billed per Post returned, so this bounds what one analytics
-     * load can cost as much as it bounds how long it takes.
-     */
+    /** Each page is billed per Post returned, so this bounds cost as well as time. */
     private const MAX_TIMELINE_PAGES = 5;
 
     private string $baseUrl;
@@ -75,14 +72,11 @@ class XAnalytics
     }
 
     /**
-     * Walk the account's timeline, summing each Post's public_metrics as the
-     * pages come back.
+     * Walk the timeline, summing public_metrics as the pages come back.
      *
-     * The metrics are requested from the timeline itself rather than looked up
-     * afterwards from /2/tweets. Both endpoints bill per Post returned, so
-     * re-reading the same ids only bought a second round-trip and a second
-     * claim on the same rate limit — the ids were already in hand, and their
-     * metrics come along for free on the request that fetched them.
+     * Asked for on the timeline request rather than looked up afterwards from
+     * /2/tweets: both bill per Post returned, so re-reading the same ids only
+     * bought a second round-trip.
      *
      * @return array{0: array<string, int>, 1: int} totals, and how many Posts fed them
      */

--- a/app/Services/Social/XAnalytics.php
+++ b/app/Services/Social/XAnalytics.php
@@ -16,6 +16,12 @@ class XAnalytics
 {
     use HasSocialHttpClient;
 
+    /**
+     * Each page is billed per Post returned, so this bounds what one analytics
+     * load can cost as much as it bounds how long it takes.
+     */
+    private const MAX_TIMELINE_PAGES = 5;
+
     private string $baseUrl;
 
     private string $accessToken;
@@ -52,27 +58,54 @@ class XAnalytics
 
         $this->accessToken = $account->access_token;
 
-        // Fetch recent tweets in the period
-        $tweetIds = $this->fetchTweetIds($account, $since, $until);
+        [$totals, $tweetCount] = $this->fetchTimelineMetrics($account, $since, $until);
 
-        if (empty($tweetIds)) {
+        if ($tweetCount === 0) {
             return [];
         }
 
-        // Fetch public_metrics for those tweets
-        return $this->fetchTweetMetrics($tweetIds);
+        return [
+            ['label' => __('analytics.metrics.impressions'), 'value' => $totals['impression_count']],
+            ['label' => __('analytics.metrics.likes'), 'value' => $totals['like_count']],
+            ['label' => __('analytics.metrics.retweets'), 'value' => $totals['retweet_count']],
+            ['label' => __('analytics.metrics.replies'), 'value' => $totals['reply_count']],
+            ['label' => __('analytics.metrics.quotes'), 'value' => $totals['quote_count']],
+            ['label' => __('analytics.metrics.bookmarks'), 'value' => $totals['bookmark_count']],
+        ];
     }
 
-    private function fetchTweetIds(SocialAccount $account, CarbonInterface $since, CarbonInterface $until): array
+    /**
+     * Walk the account's timeline, summing each Post's public_metrics as the
+     * pages come back.
+     *
+     * The metrics are requested from the timeline itself rather than looked up
+     * afterwards from /2/tweets. Both endpoints bill per Post returned, so
+     * re-reading the same ids only bought a second round-trip and a second
+     * claim on the same rate limit — the ids were already in hand, and their
+     * metrics come along for free on the request that fetched them.
+     *
+     * @return array{0: array<string, int>, 1: int} totals, and how many Posts fed them
+     */
+    private function fetchTimelineMetrics(SocialAccount $account, CarbonInterface $since, CarbonInterface $until): array
     {
-        $ids = [];
+        $totals = [
+            'impression_count' => 0,
+            'like_count' => 0,
+            'retweet_count' => 0,
+            'reply_count' => 0,
+            'quote_count' => 0,
+            'bookmark_count' => 0,
+        ];
+
+        $tweetCount = 0;
         $paginationToken = null;
 
-        for ($i = 0; $i < 5; $i++) {
+        for ($page = 0; $page < self::MAX_TIMELINE_PAGES; $page++) {
             $params = [
                 'start_time' => $since->toIso8601ZuluString(),
                 'end_time' => $until->toIso8601ZuluString(),
                 'max_results' => 100,
+                'tweet.fields' => 'public_metrics',
             ];
 
             if ($paginationToken) {
@@ -90,10 +123,14 @@ class XAnalytics
             }
 
             $data = $response->json();
-            $tweets = data_get($data, 'data', []);
 
-            foreach ($tweets as $tweet) {
-                $ids[] = data_get($tweet, 'id');
+            foreach (data_get($data, 'data', []) as $tweet) {
+                $tweetCount++;
+                $metrics = data_get($tweet, 'public_metrics', []);
+
+                foreach (array_keys($totals) as $metric) {
+                    $totals[$metric] += (int) data_get($metrics, $metric, 0);
+                }
             }
 
             $paginationToken = data_get($data, 'meta.next_token');
@@ -103,54 +140,7 @@ class XAnalytics
             }
         }
 
-        return $ids;
-    }
-
-    private function fetchTweetMetrics(array $tweetIds): array
-    {
-        $totals = [
-            'impression_count' => 0,
-            'like_count' => 0,
-            'retweet_count' => 0,
-            'reply_count' => 0,
-            'quote_count' => 0,
-            'bookmark_count' => 0,
-        ];
-
-        // X API allows max 100 IDs per request
-        foreach (array_chunk($tweetIds, 100) as $chunk) {
-            $response = $this->getHttpClient()
-                ->get("{$this->baseUrl}/tweets", [
-                    'ids' => implode(',', $chunk),
-                    'tweet.fields' => 'public_metrics',
-                ]);
-
-            if ($response->failed()) {
-                Log::warning('X tweets metrics fetch failed', [
-                    'body' => $this->redactResponseBody($response->body()),
-                ]);
-
-                continue;
-            }
-
-            $tweets = data_get($response->json(), 'data', []);
-
-            foreach ($tweets as $tweet) {
-                $metrics = data_get($tweet, 'public_metrics', []);
-                foreach ($totals as $key => &$total) {
-                    $total += data_get($metrics, $key, 0);
-                }
-            }
-        }
-
-        return [
-            ['label' => __('analytics.metrics.impressions'), 'value' => $totals['impression_count']],
-            ['label' => __('analytics.metrics.likes'), 'value' => $totals['like_count']],
-            ['label' => __('analytics.metrics.retweets'), 'value' => $totals['retweet_count']],
-            ['label' => __('analytics.metrics.replies'), 'value' => $totals['reply_count']],
-            ['label' => __('analytics.metrics.quotes'), 'value' => $totals['quote_count']],
-            ['label' => __('analytics.metrics.bookmarks'), 'value' => $totals['bookmark_count']],
-        ];
+        return [$totals, $tweetCount];
     }
 
     public function fetchPostMetrics(PostPlatform $postPlatform): array

--- a/tests/Feature/AnalyticsResilienceTest.php
+++ b/tests/Feature/AnalyticsResilienceTest.php
@@ -6,6 +6,7 @@ use App\Enums\SocialAccount\Status;
 use App\Models\SocialAccount;
 use App\Models\User;
 use App\Models\Workspace;
+use App\Services\Social\XAnalytics;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -34,4 +35,26 @@ test('analytics degrades to empty when a refresh is already in flight', function
     // a page the user just opened is a worse answer than no numbers.
     $response->assertOk();
     expect($response->json('metrics'))->toBe([]);
+});
+
+test('a bug in a metrics service is not hidden behind empty numbers', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+    $user->update(['current_workspace_id' => $workspace->id]);
+
+    $account = SocialAccount::factory()->x()->create([
+        'workspace_id' => $workspace->id,
+        'status' => Status::Connected,
+        'token_expires_at' => now()->addHours(2),
+    ]);
+
+    $this->mock(XAnalytics::class)
+        ->shouldReceive('getMetrics')
+        ->andThrow(new RuntimeException('a real bug, not the platform being down'));
+
+    // Degrading to [] here would show the user an empty dashboard and leave a
+    // genuine defect looking like "this account has no activity".
+    $this->actingAs($user)
+        ->getJson(route('app.analytics.show', $account))
+        ->assertStatus(500);
 });

--- a/tests/Feature/AnalyticsResilienceTest.php
+++ b/tests/Feature/AnalyticsResilienceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\SocialAccount\Status;
+use App\Models\SocialAccount;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+test('analytics degrades to empty when a refresh is already in flight', function () {
+    $user = User::factory()->create();
+    $workspace = Workspace::factory()->create(['user_id' => $user->id]);
+    $user->update(['current_workspace_id' => $workspace->id]);
+
+    $account = SocialAccount::factory()->x()->create([
+        'workspace_id' => $workspace->id,
+        'status' => Status::Connected,
+        'platform_user_id' => '4242',
+        // Expired, so the analytics service tries to refresh before reading.
+        'token_expires_at' => now()->subMinutes(5),
+    ]);
+
+    Http::fake(['*' => Http::response(['data' => [], 'meta' => []], 200)]);
+
+    // The scheduled RefreshSocialToken is mid-refresh for this account.
+    Cache::lock("token_refresh:{$account->id}", 120)->get();
+
+    $response = $this->actingAs($user)->getJson(route('app.analytics.show', $account));
+
+    // A transient collision is not a server error. Before the lock started
+    // reporting itself as transient this returned empty metrics, and a 500 on
+    // a page the user just opened is a worse answer than no numbers.
+    $response->assertOk();
+    expect($response->json('metrics'))->toBe([]);
+});

--- a/tests/Feature/Commands/RefreshExpiringTokensTest.php
+++ b/tests/Feature/Commands/RefreshExpiringTokensTest.php
@@ -146,3 +146,19 @@ test('a backed-up queue cannot stack duplicate refresh jobs for one account', fu
     // widens the window where a worker death loses the pair.
     Queue::assertPushed(RefreshSocialToken::class, 1);
 });
+
+test('the command reports accounts in the window, not jobs it cannot know landed', function () {
+    Queue::fake();
+
+    SocialAccount::factory()->x()->create([
+        'workspace_id' => Workspace::factory()->create()->id,
+        'status' => Status::Connected,
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
+    // RefreshSocialToken is unique per account, so a second dispatch while the
+    // first is in flight is silently discarded. dispatch() still returns a
+    // PendingDispatch either way, so a "dispatched" count would be a guess.
+    $this->artisan('social:refresh-expiring-tokens')
+        ->expectsOutput('1 accounts due for a token refresh.');
+});

--- a/tests/Feature/Commands/RefreshExpiringTokensTest.php
+++ b/tests/Feature/Commands/RefreshExpiringTokensTest.php
@@ -127,3 +127,22 @@ test('it dispatches nothing when no tokens are expiring', function () {
 
     Queue::assertNothingPushed();
 });
+
+test('a backed-up queue cannot stack duplicate refresh jobs for one account', function () {
+    Queue::fake();
+
+    SocialAccount::factory()->x()->create([
+        'workspace_id' => Workspace::factory()->create()->id,
+        'status' => Status::Connected,
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
+    // Two scheduler ticks before the first job got a worker: token_expires_at
+    // has not moved, so the account is still inside the window.
+    $this->artisan('social:refresh-expiring-tokens');
+    $this->artisan('social:refresh-expiring-tokens');
+
+    // Each extra job rotates a single-use refresh_token again for nothing, and
+    // widens the window where a worker death loses the pair.
+    Queue::assertPushed(RefreshSocialToken::class, 1);
+});

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -26,23 +26,22 @@ beforeEach(function () {
     ]);
 });
 
-test('refresh job routes through verify (access-token-first) not refreshToken', function () {
+test('refresh job routes through refreshToken, never the billed verify endpoint', function () {
     $verifier = mock(ConnectionVerifier::class);
-    $verifier->shouldReceive('verify')->once()->with(
+    $verifier->shouldReceive('refreshToken')->once()->with(
         Mockery::on(fn ($account) => $account->id === $this->account->id)
     );
-    $verifier->shouldNotReceive('refreshToken');
+    $verifier->shouldNotReceive('verify');
     app()->instance(ConnectionVerifier::class, $verifier);
 
     (new RefreshSocialToken($this->account))->handle($verifier);
 });
 
-test('proactive refresh does NOT rotate the X refresh token while the access token still works', function () {
+test('proactive refresh rotates the X refresh token without disconnecting the account', function () {
     Http::fake([
-        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
         config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
-            'access_token' => 'should-not-be-used',
-            'refresh_token' => 'should-not-be-used',
+            'access_token' => 'rotated-access-token',
+            'refresh_token' => 'rotated-refresh-token',
             'expires_in' => 7200,
         ], 200),
     ]);
@@ -55,9 +54,9 @@ test('proactive refresh does NOT rotate the X refresh token while the access tok
 
     (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
 
-    Http::assertSent(fn ($request) => str_contains($request->url(), '/users/me'));
-    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/oauth2/token'));
-    expect($this->account->fresh()->refresh_token)->toBe('original-refresh-token');
+    // X single-uses the refresh_token, so rotating one proactively has to leave
+    // the account healthy instead of tripping a false-positive disconnect.
+    expect($this->account->fresh()->refresh_token)->toBe('rotated-refresh-token');
     expect($this->account->fresh()->status)->toBe(Status::Connected);
 });
 
@@ -133,7 +132,7 @@ test('refresh job marks account as TokenExpired when refresh_token is rejected',
     Queue::fake();
 
     $verifier = mock(ConnectionVerifier::class);
-    $verifier->shouldReceive('verify')->once()->andThrow(
+    $verifier->shouldReceive('refreshToken')->once()->andThrow(
         new TokenExpiredException('refresh_token revoked')
     );
     app()->instance(ConnectionVerifier::class, $verifier);
@@ -155,7 +154,7 @@ test('refresh job logs warning on non-token errors and leaves status alone', fun
     });
 
     $verifier = mock(ConnectionVerifier::class);
-    $verifier->shouldReceive('verify')->once()->andThrow(new RuntimeException('network blip'));
+    $verifier->shouldReceive('refreshToken')->once()->andThrow(new RuntimeException('network blip'));
     app()->instance(ConnectionVerifier::class, $verifier);
 
     (new RefreshSocialToken($this->account))->handle($verifier);
@@ -173,7 +172,7 @@ test('refresh job does NOT mark account expired when platform is unavailable', f
     });
 
     $verifier = mock(ConnectionVerifier::class);
-    $verifier->shouldReceive('verify')->once()->andThrow(
+    $verifier->shouldReceive('refreshToken')->once()->andThrow(
         new PlatformUnavailableException('X API returned 503 during token refresh', 503)
     );
     app()->instance(ConnectionVerifier::class, $verifier);
@@ -182,4 +181,49 @@ test('refresh job does NOT mark account expired when platform is unavailable', f
 
     expect($this->account->fresh()->status)->toBe(Status::Connected);
     Queue::assertNotPushed(SendNotification::class);
+});
+
+test('proactive refresh renews a still-valid X token without spending a billed user read', function () {
+    Http::fake([
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'access_token' => 'rotated-access-token',
+            'refresh_token' => 'rotated-refresh-token',
+            'expires_in' => 7200,
+        ], 200),
+    ]);
+
+    $this->account->update([
+        'access_token' => 'original-access-token',
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    // GET /2/users/me is a billed "User: Read" ($0.010). A successful token
+    // refresh already proves the credential works, so it must not be called.
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/users/me'));
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/oauth2/token'));
+
+    expect($this->account->fresh()->access_token)->toBe('rotated-access-token');
+    expect($this->account->fresh()->token_expires_at->isAfter(now()->addHour()))->toBeTrue();
+});
+
+test('a successful refresh stamps last_verified_at so other jobs can skip verifying', function () {
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'access_token' => 'rotated-access-token',
+            'refresh_token' => 'rotated-refresh-token',
+            'expires_in' => 7200,
+        ], 200),
+    ]);
+
+    $this->account->update([
+        'token_expires_at' => now()->addMinutes(20),
+        'last_verified_at' => null,
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    expect($this->account->fresh()->last_verified_at)->not->toBeNull();
 });

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -446,10 +446,89 @@ test('a refresh lost to a concurrent one falls back to the token that won', func
 
 test('the refresh lock outlives the slowest refresh a provider can make us wait', function () {
     // Bluesky refreshes with two sequential calls (refreshSession, then the
-    // createSession re-auth), each bounded by the framework's connect + read
-    // timeouts. If the lock expires first, a second process refreshes with the
-    // same single-use refresh_token and one of the two is rejected.
-    $worstCaseSeconds = 2 * (30 + 10);
+    // createSession re-auth). If the lock expires first, a second process
+    // refreshes with the same single-use refresh_token and one of the two is
+    // rejected. Bounding the calls ourselves keeps that under the lock without
+    // holding the lock longer, which the publish path also waits on.
+    $worstCaseSeconds = 2 * (ConnectionVerifier::REFRESH_TIMEOUT_SECONDS + ConnectionVerifier::REFRESH_CONNECT_TIMEOUT_SECONDS);
 
     expect(ConnectionVerifier::REFRESH_LOCK_SECONDS)->toBeGreaterThan($worstCaseSeconds);
+});
+
+test('a rejected Instagram extension disconnects loudly instead of waiting for the token to die', function () {
+    Queue::fake();
+
+    $account = SocialAccount::factory()->create([
+        'workspace_id' => $this->workspace->id,
+        'platform' => Platform::Instagram,
+        'status' => Status::Connected,
+        'access_token' => 'still-valid-but-unextendable',
+        'token_expires_at' => now()->addHours(20),
+    ]);
+
+    Http::fake([
+        config('trypost.platforms.instagram.auth_api').'/refresh_access_token*' => Http::response([
+            'error' => ['message' => 'Invalid OAuth access token', 'type' => 'OAuthException', 'code' => 190],
+        ], 400),
+        config('trypost.platforms.instagram.graph_api').'/me*' => Http::response(['id' => '1', 'username' => 'u'], 200),
+    ]);
+
+    (new RefreshSocialToken($account))->handle(app(ConnectionVerifier::class));
+
+    // Instagram/Threads tokens cannot be refreshed once expired. Staying
+    // Connected because the token still reads means the owner is told only
+    // after it dies — by which point reconnecting is the only option left.
+    expect($account->fresh()->status)->toBe(Status::TokenExpired);
+    Queue::assertPushed(SendNotification::class);
+});
+
+test('the job survives the account being deleted while it is in flight', function () {
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response(['error' => 'invalid_grant'], 400),
+    ]);
+
+    $account = $this->account;
+    $account->update(['token_expires_at' => now()->addMinutes(20)]);
+
+    SocialAccount::whereKey($account->id)->delete();
+
+    // Guard the repro itself: a delete that silently did nothing would make
+    // this test pass without ever exercising the path it claims to cover.
+    expect(SocialAccount::find($account->id))->toBeNull();
+
+    // tries = 1, so an escaping exception lands the job straight in failed_jobs.
+    (new RefreshSocialToken($account))->handle(app(ConnectionVerifier::class));
+
+    // Reaching this line is the point: the refresh ran and the vanished row
+    // did not escape as a ModelNotFoundException.
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/oauth2/token'));
+});
+
+test('a refresh that returns an empty access token disconnects instead of looking healthy', function () {
+    Queue::fake();
+
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'access_token' => '',
+            'refresh_token' => 'rt-new',
+            'expires_in' => 7200,
+        ], 200),
+    ]);
+
+    $this->account->update(['token_expires_at' => now()->addMinutes(20)]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    // token_expires_at was just pushed 2h out, so the account would otherwise
+    // leave the refresh window looking healthy while every publish 401s.
+    expect($this->account->fresh()->status)->toBe(Status::TokenExpired);
+});
+
+test('refreshToken reports false for a platform with nothing to refresh', function () {
+    $account = SocialAccount::factory()->mastodon()->create([
+        'workspace_id' => $this->workspace->id,
+        'status' => Status::Connected,
+    ]);
+
+    expect(app(ConnectionVerifier::class)->refreshToken($account))->toBeFalse();
 });

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -443,3 +443,13 @@ test('a refresh lost to a concurrent one falls back to the token that won', func
     expect($this->account->fresh()->status)->toBe(Status::Connected);
     Queue::assertNotPushed(SendNotification::class);
 });
+
+test('the refresh lock outlives the slowest refresh a provider can make us wait', function () {
+    // Bluesky refreshes with two sequential calls (refreshSession, then the
+    // createSession re-auth), each bounded by the framework's connect + read
+    // timeouts. If the lock expires first, a second process refreshes with the
+    // same single-use refresh_token and one of the two is rejected.
+    $worstCaseSeconds = 2 * (30 + 10);
+
+    expect(ConnectionVerifier::REFRESH_LOCK_SECONDS)->toBeGreaterThan($worstCaseSeconds);
+});

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -306,14 +306,20 @@ test('a rejected refresh DOES disconnect once the access token is dead too', fun
 });
 
 test('lock skipped by a concurrent refresh does not record a verification', function () {
+    Http::fake([config('trypost.platforms.x.api').'/*' => Http::response([], 200)]);
+
+    $this->account->update([
+        'last_verified_at' => null,
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
     Cache::lock("token_refresh:{$this->account->id}", 30)->get();
 
-    $this->account->update(['last_verified_at' => null]);
-
-    app(ConnectionVerifier::class)->refreshToken($this->account);
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
 
     // Nothing was refreshed here, so nothing was proven — stamping would let
     // the daily sweep skip an account no one actually checked.
+    Http::assertNothingSent();
     expect($this->account->fresh()->last_verified_at)->toBeNull();
 });
 

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -12,6 +12,7 @@ use App\Models\SocialAccount;
 use App\Models\User;
 use App\Models\Workspace;
 use App\Services\Social\ConnectionVerifier;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
@@ -135,6 +136,10 @@ test('refresh job marks account as TokenExpired when refresh_token is rejected',
     $verifier->shouldReceive('refreshToken')->once()->andThrow(
         new TokenExpiredException('refresh_token revoked')
     );
+    // The access_token is dead too, so there is nothing left to fall back to.
+    $verifier->shouldReceive('verify')->once()->andThrow(
+        new TokenExpiredException('X access token is invalid or expired')
+    );
     app()->instance(ConnectionVerifier::class, $verifier);
 
     (new RefreshSocialToken($this->account))->handle($verifier);
@@ -226,4 +231,99 @@ test('a successful refresh stamps last_verified_at so other jobs can skip verify
     (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
 
     expect($this->account->fresh()->last_verified_at)->not->toBeNull();
+});
+
+test('a rejected refresh does not disconnect an account whose access token still works', function () {
+    Queue::fake();
+
+    Http::fake([
+        // X single-uses the refresh_token; a concurrent refresh already burned
+        // this one, so the provider rejects it — but the access_token is alive.
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'error' => 'invalid_grant',
+            'error_description' => 'Value passed for the token was invalid.',
+        ], 400),
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+    ]);
+
+    $this->account->update([
+        'access_token' => 'still-valid-access-token',
+        'refresh_token' => 'already-consumed-by-a-race',
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    // PublishToSocialPlatform hard-fails posts for a TokenExpired account, so
+    // disconnecting here would kill posts the access_token could still publish.
+    expect($this->account->fresh()->status)->toBe(Status::Connected);
+    Queue::assertNotPushed(SendNotification::class);
+});
+
+test('an account with no refresh token stays connected while its access token works', function () {
+    Queue::fake();
+
+    Http::fake([
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+    ]);
+
+    $this->account->update([
+        'access_token' => 'still-valid-access-token',
+        'refresh_token' => null,
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    expect($this->account->fresh()->status)->toBe(Status::Connected);
+    Queue::assertNotPushed(SendNotification::class);
+});
+
+test('a rejected refresh DOES disconnect once the access token is dead too', function () {
+    Queue::fake();
+
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'error' => 'invalid_grant',
+            'error_description' => 'refresh_token revoked',
+        ], 400),
+        config('trypost.platforms.x.api').'/users/me' => Http::response([
+            'title' => 'Unauthorized',
+            'status' => 401,
+        ], 401),
+    ]);
+
+    $this->account->update([
+        'access_token' => 'dead-access-token',
+        'refresh_token' => 'revoked-refresh-token',
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    expect($this->account->fresh()->status)->toBe(Status::TokenExpired);
+});
+
+test('lock skipped by a concurrent refresh does not record a verification', function () {
+    Cache::lock("token_refresh:{$this->account->id}", 30)->get();
+
+    $this->account->update(['last_verified_at' => null]);
+
+    app(ConnectionVerifier::class)->refreshToken($this->account);
+
+    // Nothing was refreshed here, so nothing was proven — stamping would let
+    // the daily sweep skip an account no one actually checked.
+    expect($this->account->fresh()->last_verified_at)->toBeNull();
+});
+
+test('a platform with nothing to refresh is never recorded as verified', function () {
+    $account = SocialAccount::factory()->mastodon()->create([
+        'workspace_id' => $this->workspace->id,
+        'status' => Status::Connected,
+        'last_verified_at' => null,
+    ]);
+
+    app(ConnectionVerifier::class)->refreshToken($account);
+
+    expect($account->fresh()->last_verified_at)->toBeNull();
 });

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -637,22 +637,25 @@ test('no platform lets a tokenless 200 destroy the credential it already had', f
     expect($checked)->toBeGreaterThan(0);
 });
 
-test('a platform outage on an already-dead token stops being silent', function () {
+test('a platform outage never disconnects, not even once the token has expired', function () {
     Queue::fake();
 
     $verifier = mock(ConnectionVerifier::class);
     $verifier->shouldReceive('refreshToken')->once()->andThrow(
-        new PlatformUnavailableException('X API returned 503 during token refresh', 503)
+        // TokenRefreshClient raises this for 5xx, 429 and connection timeouts.
+        new PlatformUnavailableException('X API returned 429 during token refresh', 429)
     );
     app()->instance(ConnectionVerifier::class, $verifier);
 
-    // Already expired: there is no live token left to retry behind.
     $this->account->update(['token_expires_at' => now()->subMinutes(5)]);
 
     (new RefreshSocialToken($this->account))->handle($verifier);
 
-    expect($this->account->fresh()->status)->toBe(Status::TokenExpired);
-    Queue::assertPushed(SendNotification::class);
+    // A rate limit around expiry is not evidence of anything. Disconnecting
+    // here emails the owner and hard-fails every scheduled post, and only the
+    // daily sweep would undo it.
+    expect($this->account->fresh()->status)->toBe(Status::Connected);
+    Queue::assertNotPushed(SendNotification::class);
 });
 
 test('a platform outage on a live token stays quiet and retries', function () {
@@ -691,4 +694,39 @@ test('a failure the fallback cannot attribute to the token surfaces instead of p
 
     expect($this->account->fresh()->status)->toBe(Status::Connected);
     Queue::assertNotPushed(SendNotification::class);
+});
+
+test('a null refresh_token in a 200 does not wipe the one we already had', function () {
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'access_token' => 'fresh-access-token',
+            'refresh_token' => null,
+            'expires_in' => 7200,
+        ], 200),
+    ]);
+
+    $this->account->update([
+        'refresh_token' => 'the-refresh-token-that-still-works',
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    // data_get() only falls back when the key is absent, so an explicit null
+    // overwrites. Losing it means the next tick throws "no refresh token"
+    // without a single call, and the account dies with the access token.
+    expect($this->account->fresh()->refresh_token)->toBe('the-refresh-token-that-still-works');
+});
+
+test('a refresh already in flight on a dead token is transient, not something to publish through', function () {
+    $this->account->update(['token_expires_at' => now()->subMinutes(5)]);
+
+    Cache::lock("token_refresh:{$this->account->id}", 120)->get();
+
+    // Returning false here hands the caller a token it already knows is dead.
+    // A publisher then posts with it, gets a 401, and PublishToSocialPlatform
+    // finalises the post as failed and disconnects the account — for a lock
+    // that a worker death left behind.
+    expect(fn () => app(ConnectionVerifier::class)->refreshToken($this->account))
+        ->toThrow(PlatformUnavailableException::class);
 });

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -504,7 +504,7 @@ test('the job survives the account being deleted while it is in flight', functio
     Http::assertSent(fn ($request) => str_contains($request->url(), '/oauth2/token'));
 });
 
-test('a refresh that returns an empty access token disconnects instead of looking healthy', function () {
+test('a 200 without a token leaves the working credential intact', function () {
     Queue::fake();
 
     Http::fake([
@@ -515,13 +515,21 @@ test('a refresh that returns an empty access token disconnects instead of lookin
         ], 200),
     ]);
 
-    $this->account->update(['token_expires_at' => now()->addMinutes(20)]);
+    $this->account->update([
+        'access_token' => 'the-token-that-still-works',
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
 
     (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
 
-    // token_expires_at was just pushed 2h out, so the account would otherwise
-    // leave the refresh window looking healthy while every publish 401s.
-    expect($this->account->fresh()->status)->toBe(Status::TokenExpired);
+    // Persisting the empty token would destroy a credential that still works,
+    // and no amount of after-the-fact detection gets it back.
+    expect($this->account->fresh()->access_token)->toBe('the-token-that-still-works');
+
+    // And it must not disconnect: the refresh_token is probably fine, so the
+    // next tick should retry rather than emailing the owner to reconnect.
+    expect($this->account->fresh()->status)->toBe(Status::Connected);
+    Queue::assertNotPushed(SendNotification::class);
 });
 
 test('refreshToken reports false for a platform with nothing to refresh', function () {

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -532,3 +532,43 @@ test('refreshToken reports false for a platform with nothing to refresh', functi
 
     expect(app(ConnectionVerifier::class)->refreshToken($account))->toBeFalse();
 });
+
+test('every platform that claims a refresh flow has one implemented', function () {
+    Http::fake(['*' => Http::response([
+        'access_token' => 'at', 'refresh_token' => 'rt', 'expires_in' => 3600,
+        'accessJwt' => 'j', 'refreshJwt' => 'r', 'id' => '1', 'data' => ['id' => '1'],
+    ], 200)]);
+
+    $verifier = app(ConnectionVerifier::class);
+    $checked = 0;
+
+    foreach (Platform::cases() as $platform) {
+        if (! $platform->hasTokenRefreshFlow()) {
+            continue;
+        }
+
+        $checked++;
+
+        $account = SocialAccount::factory()->create([
+            'workspace_id' => Workspace::factory()->create()->id,
+            'platform' => $platform,
+            'status' => Status::Connected,
+            'refresh_token' => 'rt-seed',
+            'meta' => ['service' => 'https://bsky.social', 'identifier' => 'a.bsky.social'],
+        ]);
+
+        try {
+            $verifier->refreshToken($account);
+        } catch (UnhandledMatchError $e) {
+            // refreshToken()'s match has no default arm, so a platform added to
+            // hasTokenRefreshFlow() without one blows up in production instead
+            // of falling through quietly.
+            $this->fail("{$platform->value} claims a refresh flow but refreshToken() has no arm for it");
+        } catch (Throwable) {
+            // Provider-specific failures are irrelevant here; only the missing
+            // arm is what this guards.
+        }
+    }
+
+    expect($checked)->toBeGreaterThan(0);
+});

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -13,6 +13,7 @@ use App\Models\User;
 use App\Models\Workspace;
 use App\Services\Social\ConnectionVerifier;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
@@ -400,4 +401,39 @@ test('a rejected refresh is not re-sent before the access token is checked', fun
         ->count();
 
     expect($refreshCalls)->toBe(1);
+});
+
+test('a refresh lost to a concurrent one falls back to the token that won', function () {
+    Queue::fake();
+
+    $api = config('trypost.platforms.x.api');
+    Http::fake([
+        // Our refresh_token was already consumed by the process that won.
+        $api.'/oauth2/token' => Http::response(['error' => 'invalid_grant'], 400),
+        $api.'/users/me' => function ($request) {
+            $auth = $request->header('Authorization')[0] ?? '';
+
+            return str_contains($auth, 'winner-access-token')
+                ? Http::response(['data' => ['id' => '123']], 200)
+                : Http::response(['title' => 'Unauthorized', 'status' => 401], 401);
+        },
+    ]);
+
+    $this->account->update([
+        'access_token' => 'stale-access-token',
+        'refresh_token' => 'stale-refresh-token',
+        'token_expires_at' => now()->addMinutes(20),
+    ]);
+
+    // The winner persisted its new pair while ours was in flight; this
+    // instance still holds the rotated-away one.
+    DB::table('social_accounts')->where('id', $this->account->id)->update([
+        'access_token' => 'winner-access-token',
+        'refresh_token' => 'winner-refresh-token',
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    expect($this->account->fresh()->status)->toBe(Status::Connected);
+    Queue::assertNotPushed(SendNotification::class);
 });

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -432,14 +432,19 @@ test('a refresh lost to a concurrent one falls back to the token that won', func
     ]);
 
     // The winner persisted its new pair while ours was in flight; this
-    // instance still holds the rotated-away one.
-    DB::table('social_accounts')->where('id', $this->account->id)->update([
+    // instance still holds the rotated-away one. Written through a separate
+    // model so the encrypted casts apply — a raw DB write stores plaintext,
+    // and reading it back throws DecryptException instead of exercising this.
+    SocialAccount::find($this->account->id)->update([
         'access_token' => 'winner-access-token',
         'refresh_token' => 'winner-refresh-token',
     ]);
 
     (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
 
+    // The recovery is the point: reload, find the winner's token, verify with
+    // it. Asserting the call proves we got that far rather than bailing early.
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/users/me'));
     expect($this->account->fresh()->status)->toBe(Status::Connected);
     Queue::assertNotPushed(SendNotification::class);
 });
@@ -630,4 +635,60 @@ test('no platform lets a tokenless 200 destroy the credential it already had', f
 
     Queue::assertNotPushed(SendNotification::class);
     expect($checked)->toBeGreaterThan(0);
+});
+
+test('a platform outage on an already-dead token stops being silent', function () {
+    Queue::fake();
+
+    $verifier = mock(ConnectionVerifier::class);
+    $verifier->shouldReceive('refreshToken')->once()->andThrow(
+        new PlatformUnavailableException('X API returned 503 during token refresh', 503)
+    );
+    app()->instance(ConnectionVerifier::class, $verifier);
+
+    // Already expired: there is no live token left to retry behind.
+    $this->account->update(['token_expires_at' => now()->subMinutes(5)]);
+
+    (new RefreshSocialToken($this->account))->handle($verifier);
+
+    expect($this->account->fresh()->status)->toBe(Status::TokenExpired);
+    Queue::assertPushed(SendNotification::class);
+});
+
+test('a platform outage on a live token stays quiet and retries', function () {
+    Queue::fake();
+
+    $verifier = mock(ConnectionVerifier::class);
+    $verifier->shouldReceive('refreshToken')->once()->andThrow(
+        new PlatformUnavailableException('X API returned 503 during token refresh', 503)
+    );
+    app()->instance(ConnectionVerifier::class, $verifier);
+
+    $this->account->update(['token_expires_at' => now()->addMinutes(20)]);
+
+    (new RefreshSocialToken($this->account))->handle($verifier);
+
+    expect($this->account->fresh()->status)->toBe(Status::Connected);
+    Queue::assertNotPushed(SendNotification::class);
+});
+
+test('a failure the fallback cannot attribute to the token surfaces instead of passing as healthy', function () {
+    Queue::fake();
+
+    $verifier = mock(ConnectionVerifier::class);
+    $verifier->shouldReceive('refreshToken')->once()->andThrow(new TokenExpiredException('rejected'));
+    // e.g. a decrypt failure after an APP_KEY rotation, or an unhandled match
+    // for a platform someone just added.
+    $verifier->shouldReceive('verifyAccessToken')->once()->andThrow(new RuntimeException('cannot decrypt'));
+    app()->instance(ConnectionVerifier::class, $verifier);
+
+    // Swallowing this would leave the account Connected forever while every
+    // publish hard-fails. It has to reach failed_jobs where someone sees it —
+    // and it must not disconnect users, since an APP_KEY rotation breaks all
+    // of them at once.
+    expect(fn () => (new RefreshSocialToken($this->account))->handle($verifier))
+        ->toThrow(RuntimeException::class);
+
+    expect($this->account->fresh()->status)->toBe(Status::Connected);
+    Queue::assertNotPushed(SendNotification::class);
 });

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -533,12 +533,7 @@ test('refreshToken reports false for a platform with nothing to refresh', functi
     expect(app(ConnectionVerifier::class)->refreshToken($account))->toBeFalse();
 });
 
-test('every platform that claims a refresh flow has one implemented', function () {
-    Http::fake(['*' => Http::response([
-        'access_token' => 'at', 'refresh_token' => 'rt', 'expires_in' => 3600,
-        'accessJwt' => 'j', 'refreshJwt' => 'r', 'id' => '1', 'data' => ['id' => '1'],
-    ], 200)]);
-
+test('every platform that claims a refresh flow actually performs one', function () {
     $verifier = app(ConnectionVerifier::class);
     $checked = 0;
 
@@ -557,6 +552,11 @@ test('every platform that claims a refresh flow has one implemented', function (
             'meta' => ['service' => 'https://bsky.social', 'identifier' => 'a.bsky.social'],
         ]);
 
+        Http::fake(['*' => Http::response([
+            'access_token' => 'at', 'refresh_token' => 'rt', 'expires_in' => 3600,
+            'accessJwt' => 'j', 'refreshJwt' => 'r', 'id' => '1', 'data' => ['id' => '1'],
+        ], 200)]);
+
         try {
             $verifier->refreshToken($account);
         } catch (UnhandledMatchError $e) {
@@ -564,10 +564,15 @@ test('every platform that claims a refresh flow has one implemented', function (
             // hasTokenRefreshFlow() without one blows up in production instead
             // of falling through quietly.
             $this->fail("{$platform->value} claims a refresh flow but refreshToken() has no arm for it");
-        } catch (Throwable) {
-            // Provider-specific failures are irrelevant here; only the missing
-            // arm is what this guards.
+        } catch (Throwable $e) {
+            $this->fail("{$platform->value} refresh threw ".$e::class.': '.$e->getMessage());
         }
+
+        // A broken client chain (a renamed helper, a method that no longer
+        // exists on PendingRequest) raises before anything leaves the process,
+        // so "no request sent" is the signal that catches it.
+        expect(Http::recorded())
+            ->not->toBeEmpty("{$platform->value} refresh sent no HTTP request at all");
     }
 
     expect($checked)->toBeGreaterThan(0);

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -32,7 +32,7 @@ test('refresh job routes through refreshToken, never the billed verify endpoint'
     $verifier = mock(ConnectionVerifier::class);
     $verifier->shouldReceive('refreshToken')->once()->with(
         Mockery::on(fn ($account) => $account->id === $this->account->id)
-    );
+    )->andReturnTrue();
     $verifier->shouldNotReceive('verify');
     app()->instance(ConnectionVerifier::class, $verifier);
 

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -585,3 +585,49 @@ test('every platform that claims a refresh flow actually performs one', function
 
     expect($checked)->toBeGreaterThan(0);
 });
+
+test('no platform lets a tokenless 200 destroy the credential it already had', function () {
+    Queue::fake();
+
+    $verifier = app(ConnectionVerifier::class);
+    $checked = 0;
+
+    foreach (Platform::cases() as $platform) {
+        if (! $platform->hasTokenRefreshFlow()) {
+            continue;
+        }
+
+        $checked++;
+
+        $account = SocialAccount::factory()->create([
+            'workspace_id' => Workspace::factory()->create()->id,
+            'platform' => $platform,
+            'status' => Status::Connected,
+            'access_token' => 'the-token-that-still-works',
+            'refresh_token' => 'rt-seed',
+            'meta' => ['service' => 'https://bsky.social', 'identifier' => 'a.bsky.social'],
+        ]);
+
+        // A 200 carrying no token at all. Every provider reads a different
+        // field name, so this is the shape none of them can parse.
+        Http::fake(['*' => Http::response(['expires_in' => 3600], 200)]);
+
+        try {
+            $verifier->refreshToken($account);
+            $this->fail("{$platform->value} accepted a 200 with no token in it");
+        } catch (PlatformUnavailableException) {
+            // Correct: nothing is provably dead, so refuse and let the next
+            // tick retry rather than disconnecting anyone.
+        } catch (Throwable $e) {
+            // Without the guard the write reaches the database and trips the
+            // NOT NULL column, which also poisons the surrounding transaction.
+            $this->fail("{$platform->value} should refuse a tokenless 200 cleanly, got ".$e::class.': '.$e->getMessage());
+        }
+
+        expect($account->fresh()->access_token)
+            ->toBe('the-token-that-still-works', "{$platform->value} overwrote a working token with nothing");
+    }
+
+    Queue::assertNotPushed(SendNotification::class);
+    expect($checked)->toBeGreaterThan(0);
+});

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -730,3 +730,22 @@ test('a refresh already in flight on a dead token is transient, not something to
     expect(fn () => app(ConnectionVerifier::class)->refreshToken($this->account))
         ->toThrow(PlatformUnavailableException::class);
 });
+
+test('a billed fallback check counts as a verification like any other', function () {
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response(['error' => 'invalid_grant'], 400),
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+    ]);
+
+    $this->account->update([
+        'access_token' => 'still-valid-access-token',
+        'token_expires_at' => now()->addMinutes(20),
+        'last_verified_at' => null,
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    // GET /2/users/me is billed and it just proved the token alive. Throwing
+    // that away means the pre-publish check pays to ask again minutes later.
+    expect($this->account->fresh()->last_verified_at)->not->toBeNull();
+});

--- a/tests/Feature/Jobs/RefreshSocialTokenTest.php
+++ b/tests/Feature/Jobs/RefreshSocialTokenTest.php
@@ -137,7 +137,7 @@ test('refresh job marks account as TokenExpired when refresh_token is rejected',
         new TokenExpiredException('refresh_token revoked')
     );
     // The access_token is dead too, so there is nothing left to fall back to.
-    $verifier->shouldReceive('verify')->once()->andThrow(
+    $verifier->shouldReceive('verifyAccessToken')->once()->andThrow(
         new TokenExpiredException('X access token is invalid or expired')
     );
     app()->instance(ConnectionVerifier::class, $verifier);
@@ -326,4 +326,78 @@ test('a platform with nothing to refresh is never recorded as verified', functio
     app(ConnectionVerifier::class)->refreshToken($account);
 
     expect($account->fresh()->last_verified_at)->toBeNull();
+});
+
+test('a refresh whose follow-up verify fails is not recorded as a verification', function () {
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'access_token' => 'fresh-but-rejected',
+            'refresh_token' => 'rt-new',
+            'expires_in' => 7200,
+        ], 200),
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['title' => 'Unauthorized'], 401),
+    ]);
+
+    $this->account->update([
+        'token_expires_at' => now()->subMinute(),
+        'last_verified_at' => null,
+    ]);
+
+    try {
+        app(ConnectionVerifier::class)->verify($this->account);
+    } catch (TokenExpiredException) {
+        // expected — the refreshed token is rejected too
+    }
+
+    // The refresh succeeded but the credential was never proven good. Stamping
+    // here lets both skip-windows wave through an account nobody verified.
+    expect($this->account->fresh()->last_verified_at)->toBeNull();
+});
+
+test('a refresh that returns an empty access token is not recorded as a verification', function () {
+    // TokenRefreshClient classifies on HTTP status alone and never inspects the
+    // body, so a 200 carrying an empty token is stored as-is.
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'access_token' => '',
+            'refresh_token' => 'rt-new',
+            'expires_in' => 7200,
+        ], 200),
+    ]);
+
+    $this->account->update([
+        'token_expires_at' => now()->addMinutes(20),
+        'last_verified_at' => null,
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    expect($this->account->fresh()->last_verified_at)->toBeNull();
+});
+
+test('a rejected refresh is not re-sent before the access token is checked', function () {
+    Queue::fake();
+
+    Http::fake([
+        config('trypost.platforms.x.api').'/oauth2/token' => Http::response([
+            'error' => 'invalid_grant',
+        ], 400),
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+    ]);
+
+    $this->account->update([
+        'access_token' => 'still-valid-access-token',
+        'refresh_token' => 'already-consumed-by-a-race',
+        'token_expires_at' => now()->subMinute(),
+    ]);
+
+    (new RefreshSocialToken($this->account))->handle(app(ConnectionVerifier::class));
+
+    // Going through verify() would re-send the refresh_token the provider just
+    // rejected — and on Bluesky re-run the rate-limited password re-auth.
+    $refreshCalls = collect(Http::recorded())
+        ->filter(fn ($pair) => str_contains($pair[0]->url(), '/oauth2/token'))
+        ->count();
+
+    expect($refreshCalls)->toBe(1);
 });

--- a/tests/Feature/VerifyWorkspaceConnectionsTest.php
+++ b/tests/Feature/VerifyWorkspaceConnectionsTest.php
@@ -216,3 +216,23 @@ test('daily sweep still verifies a TokenExpired account despite a fresh last_ver
     Http::assertSent(fn ($request) => str_contains($request->url(), '/users/me'));
     expect($account->fresh()->status)->toBe(Status::Connected);
 });
+
+test('daily sweep records its own successful verification', function () {
+    Mail::fake();
+    Http::fake([
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+    ]);
+
+    $workspace = Workspace::factory()->create();
+    $account = SocialAccount::factory()->x()->create([
+        'workspace_id' => $workspace->id,
+        'status' => Status::Connected,
+        'last_verified_at' => null,
+    ]);
+
+    VerifyWorkspaceConnections::dispatch($workspace);
+
+    // Otherwise VerifyUpcomingPostConnections burns a fresh call minutes later
+    // on an account this sweep just confirmed healthy.
+    expect($account->fresh()->last_verified_at)->not->toBeNull();
+});

--- a/tests/Feature/VerifyWorkspaceConnectionsTest.php
+++ b/tests/Feature/VerifyWorkspaceConnectionsTest.php
@@ -236,3 +236,23 @@ test('daily sweep records its own successful verification', function () {
     // on an account this sweep just confirmed healthy.
     expect($account->fresh()->last_verified_at)->not->toBeNull();
 });
+
+test('an unreachable platform does not revive an account nobody verified', function () {
+    Mail::fake();
+
+    $workspace = Workspace::factory()->create();
+    $account = SocialAccount::factory()->x()->create([
+        'workspace_id' => $workspace->id,
+        'status' => Status::TokenExpired,
+    ]);
+
+    $verifier = mock(ConnectionVerifier::class);
+    $verifier->shouldReceive('verify')->andThrow(new PlatformUnavailableException('X API returned 503', 503));
+    app()->instance(ConnectionVerifier::class, $verifier);
+
+    VerifyWorkspaceConnections::dispatch($workspace);
+
+    // "Don't disconnect" is not the same as "verified". Promoting on an
+    // outage tells the owner their reconnect worked when nothing was checked.
+    expect($account->fresh()->status)->toBe(Status::TokenExpired);
+});

--- a/tests/Feature/VerifyWorkspaceConnectionsTest.php
+++ b/tests/Feature/VerifyWorkspaceConnectionsTest.php
@@ -10,6 +10,7 @@ use App\Mail\WorkspaceConnectionsDisconnected;
 use App\Models\SocialAccount;
 use App\Models\Workspace;
 use App\Services\Social\ConnectionVerifier;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 
 test('job does nothing when workspace has no connected accounts', function () {
@@ -155,4 +156,63 @@ test('job skips already disconnected accounts', function () {
     VerifyWorkspaceConnections::dispatch($workspace);
 
     Mail::assertNothingSent();
+});
+
+test('daily sweep skips verifying a connected account a recent refresh already proved valid', function () {
+    Mail::fake();
+    Http::fake([
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+    ]);
+
+    $workspace = Workspace::factory()->create();
+    SocialAccount::factory()->x()->create([
+        'workspace_id' => $workspace->id,
+        'status' => Status::Connected,
+        'last_verified_at' => now()->subHours(2),
+    ]);
+
+    VerifyWorkspaceConnections::dispatch($workspace);
+
+    // A successful token refresh within the trust window already proved the
+    // credential — re-reading the profile would only burn a billed User Read.
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/users/me'));
+    Mail::assertNothingSent();
+});
+
+test('daily sweep still verifies a connected account whose last_verified_at is stale', function () {
+    Mail::fake();
+    Http::fake([
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+    ]);
+
+    $workspace = Workspace::factory()->create();
+    SocialAccount::factory()->x()->create([
+        'workspace_id' => $workspace->id,
+        'status' => Status::Connected,
+        'last_verified_at' => now()->subHours(20),
+    ]);
+
+    VerifyWorkspaceConnections::dispatch($workspace);
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/users/me'));
+});
+
+test('daily sweep still verifies a TokenExpired account despite a fresh last_verified_at', function () {
+    Mail::fake();
+    Http::fake([
+        config('trypost.platforms.x.api').'/users/me' => Http::response(['data' => ['id' => '123']], 200),
+    ]);
+
+    $workspace = Workspace::factory()->create();
+    $account = SocialAccount::factory()->x()->create([
+        'workspace_id' => $workspace->id,
+        'status' => Status::TokenExpired,
+        'last_verified_at' => now()->subMinutes(5),
+    ]);
+
+    VerifyWorkspaceConnections::dispatch($workspace);
+
+    // Skipping here would strand a recovered account in TokenExpired forever.
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/users/me'));
+    expect($account->fresh()->status)->toBe(Status::Connected);
 });

--- a/tests/Feature/XAnalyticsTest.php
+++ b/tests/Feature/XAnalyticsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\SocialAccount;
+use App\Models\Workspace;
+use App\Services\Social\XAnalytics;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->account = SocialAccount::factory()->x()->create([
+        'workspace_id' => Workspace::factory()->create()->id,
+        'platform_user_id' => '4242',
+        'token_expires_at' => now()->addHours(2),
+    ]);
+    $this->api = config('trypost.platforms.x.api');
+});
+
+test('metrics come from the timeline itself instead of a second lookup of the same posts', function () {
+    Http::fake([
+        $this->api.'/users/4242/tweets*' => Http::response([
+            'data' => [
+                ['id' => '1', 'public_metrics' => ['impression_count' => 100, 'like_count' => 10, 'retweet_count' => 1, 'reply_count' => 2, 'quote_count' => 3, 'bookmark_count' => 4]],
+                ['id' => '2', 'public_metrics' => ['impression_count' => 200, 'like_count' => 20, 'retweet_count' => 2, 'reply_count' => 4, 'quote_count' => 6, 'bookmark_count' => 8]],
+            ],
+            'meta' => [],
+        ], 200),
+    ]);
+
+    $metrics = app(XAnalytics::class)->getMetrics($this->account);
+
+    // Every post returned is a billed Post read. Re-reading the same ids from
+    // /2/tweets buys nothing the timeline could not have returned.
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/2/tweets?')
+        || preg_match('#/tweets\?ids=#', $request->url()) === 1);
+
+    expect(collect($metrics)->firstWhere('label', __('analytics.metrics.impressions'))['value'])->toBe(300);
+    expect(collect($metrics)->firstWhere('label', __('analytics.metrics.likes'))['value'])->toBe(30);
+});
+
+test('the timeline request asks for public_metrics', function () {
+    Http::fake([
+        $this->api.'/users/4242/tweets*' => Http::response(['data' => [], 'meta' => []], 200),
+    ]);
+
+    app(XAnalytics::class)->getMetrics($this->account);
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'tweet.fields=public_metrics'));
+});
+
+test('metrics accumulate across paginated timeline pages', function () {
+    Http::fake([
+        $this->api.'/users/4242/tweets*' => Http::sequence()
+            ->push([
+                'data' => [['id' => '1', 'public_metrics' => ['impression_count' => 100, 'like_count' => 1, 'retweet_count' => 0, 'reply_count' => 0, 'quote_count' => 0, 'bookmark_count' => 0]]],
+                'meta' => ['next_token' => 'page2'],
+            ], 200)
+            ->push([
+                'data' => [['id' => '2', 'public_metrics' => ['impression_count' => 50, 'like_count' => 2, 'retweet_count' => 0, 'reply_count' => 0, 'quote_count' => 0, 'bookmark_count' => 0]]],
+                'meta' => [],
+            ], 200),
+    ]);
+
+    $metrics = app(XAnalytics::class)->getMetrics($this->account);
+
+    expect(collect($metrics)->firstWhere('label', __('analytics.metrics.impressions'))['value'])->toBe(150);
+    expect(collect($metrics)->firstWhere('label', __('analytics.metrics.likes'))['value'])->toBe(3);
+});

--- a/tests/Feature/XAnalyticsTest.php
+++ b/tests/Feature/XAnalyticsTest.php
@@ -66,3 +66,44 @@ test('metrics accumulate across paginated timeline pages', function () {
     expect(collect($metrics)->firstWhere('label', __('analytics.metrics.impressions'))['value'])->toBe(150);
     expect(collect($metrics)->firstWhere('label', __('analytics.metrics.likes'))['value'])->toBe(3);
 });
+
+test('a page that fails mid-pagination keeps the totals collected so far', function () {
+    Http::fake([
+        $this->api.'/users/4242/tweets*' => Http::sequence()
+            ->push([
+                'data' => [['id' => '1', 'public_metrics' => ['impression_count' => 100, 'like_count' => 5, 'retweet_count' => 0, 'reply_count' => 0, 'quote_count' => 0, 'bookmark_count' => 0]]],
+                'meta' => ['next_token' => 'page2'],
+            ], 200)
+            ->push(['title' => 'Internal Error'], 500),
+    ]);
+
+    $metrics = app(XAnalytics::class)->getMetrics($this->account);
+
+    // Partial data beats an exception on a dashboard the user is looking at.
+    expect(collect($metrics)->firstWhere('label', __('analytics.metrics.impressions'))['value'])->toBe(100);
+    expect(collect($metrics)->firstWhere('label', __('analytics.metrics.likes'))['value'])->toBe(5);
+});
+
+test('a post returned without public_metrics counts as zero rather than erroring', function () {
+    Http::fake([
+        $this->api.'/users/4242/tweets*' => Http::response([
+            'data' => [
+                ['id' => '1'],
+                ['id' => '2', 'public_metrics' => ['impression_count' => 7, 'like_count' => 1, 'retweet_count' => 0, 'reply_count' => 0, 'quote_count' => 0, 'bookmark_count' => 0]],
+            ],
+            'meta' => [],
+        ], 200),
+    ]);
+
+    $metrics = app(XAnalytics::class)->getMetrics($this->account);
+
+    expect(collect($metrics)->firstWhere('label', __('analytics.metrics.impressions'))['value'])->toBe(7);
+});
+
+test('an account that posted nothing in the range returns no metrics at all', function () {
+    Http::fake([
+        $this->api.'/users/4242/tweets*' => Http::response(['data' => [], 'meta' => []], 200),
+    ]);
+
+    expect(app(XAnalytics::class)->getMetrics($this->account))->toBe([]);
+});


### PR DESCRIPTION
Nightwatch showed the X API traffic dominated by `RefreshSocialToken` — a steady stream of `GET /2/users/me` and `POST /2/oauth2/token`, all day, for every connected account. Under X's pay-per-usage pricing that first endpoint is billed.

Two reads turned out to buy nothing, for the same underlying reason: the data they fetched was already in hand. This removes both.

## Part 1 — the token check

### The problem

`RefreshSocialToken` verified rotating-refresh platforms instead of refreshing them:

```php
if ($this->account->platform->extendsAccessTokenOnRefresh()) {
    $verifier->refreshToken($this->account);
} else {
    $verifier->verify($this->account);   // X, LinkedIn, YouTube, TikTok, Pinterest, Bluesky
}
```

On a **still-valid** token, `verify()` only calls the platform's verify endpoint and leaves `token_expires_at` untouched. The account therefore stays inside `RefreshExpiringTokens`' 30-minute window and is re-read at every 15-minute tick until the token actually dies — then, and only then, is it refreshed.

Two consequences:

1. **We paid to answer an auth question with a data endpoint.** On X the verify endpoint is `GET /2/users/me`, billed as a **"User: Read" — $0.010 per resource**. It returns a full profile; the code reads one boolean from it (`ConnectionVerifier.php:435`). It does not qualify for Owned Read pricing ($0.001): that list is closed, `users/me` isn't on it, and even the endpoints that are only qualify when `{id}` is the developer app's owner — never true for a multi-tenant app.
2. **The token was left dead for a stretch of every cycle**, because nothing refreshed it until after expiry.

### The change

**1. Refresh instead of verify.** A provider that hands back a fresh token has already confirmed the credential — it rejects a revoked one with a 4xx, which `TokenRefreshClient` maps to `TokenExpiredException`. More than that: the refresh doesn't *inspect* the access token, it **replaces** it. After it returns, the stored token is seconds old and minted by the provider. There is nothing left for a verify call to check.

**2. Record the confirmation.** `RefreshSocialToken` stamps `last_verified_at` on a successful refresh, guarded on the platform having a refresh flow and the response carrying a usable token.

**3. Let the sweep trust it.** `VerifyWorkspaceConnections` skips accounts verified within 12 hours — the pattern `VerifyUpcomingPostConnections` has used since #255, never wired into the other callers. Only `Connected` accounts are skipped: a `TokenExpired` one still needs the call, because verifying it is how it gets promoted back.

Net effect: all three `verify()` callers stop emitting billed reads for X. What remains on the bill is inherent to the product — post creates and analytics.

### Measured

Simulated 24h of the scheduler — all three scheduled commands, 96 ticks, 8 scheduled posts — against both branches, per platform, using each provider's real token TTL.

| Platform (TTL) | `main`: refresh + verify = total | branch: refresh + verify = total | Δ calls | min/day on a dead token |
|---|---|---|---|---|
| **X** (2h) | 12 + 36 = **48** | 16 + 0 = **16** | **−67%** | 180 → **0** |
| **YouTube** (1h) | 24 + 72 = **96** | 48 + 0 = **48** | **−50%** | **360** → **0** |
| **Bluesky** (2h) | 12 + 36 = **48** | 16 + 0 = **16** | **−67%** | 180 → **0** |
| **TikTok** (24h) | 1 + 3 = **4** | 1 + 0 = **1** | **−75%** | 15 → **0** |
| **Pinterest** (30d) | 0 | 0 | — | 0 → 0 |
| **LinkedIn** (60d) | 0 | 0 | — | 0 → 0 |
| **Instagram** (60d) | 1 | **1** (identical) | — | 0 → 0 |
| **Threads** (60d) | 1 | **1** (identical) | — | 0 → 0 |

With the daily sweep and pre-publish checks included, X goes from **45 billed reads/account/day ($0.45)** to **0**.

Every platform makes strictly fewer API calls and spends zero time holding an expired token. **YouTube was in worse shape than X** and nobody knew: a 1-hour Google token entered the 30-minute window every hour, so **6 hours a day** were spent on a dead token, with every publish in that stretch eating a 401 first.

X dedupes resources within a 24h UTC window, which had been absorbing some of this — but the docs call that a *soft guarantee* that "may result in resources not being deduplicated." This takes the number of chances to leak from 45 to zero.

### Three regressions this branch introduced, found and fixed

Worth reading before approving — each was introduced by an earlier commit here, and each was found by testing against `main`, not by reasoning.

| # | Regression | `main` | before fix | Fixed in |
|---|---|---|---|---|
| 1 | Rejected refresh disconnected an account whose access token still worked | `connected` | `token_expired` | 9775578 |
| 2 | Fallback judged the stale in-memory token after a lost rotation race | `connected` | `token_expired` | 48e4195 |
| 3 | Lock-skipped refresh recorded a verification with zero HTTP calls made | n/a | stamped | 8a3cfe8 |

**#1 was not an edge case.** Any X account with no stored `refresh_token` would hit it every cycle — 16×/day, forever, each time emailing the owner and failing their posts. And X's own developer community documents refresh tokens being **invalidated spuriously**, so it would also have fired on a known, recurring X quirk.

The pattern in all three: the verify-first code had accumulated protections (`refreshThenVerify`'s reload-and-retry, the lock's early return) that the new path didn't inherit.

The test written to cover #3 originally called `refreshToken()` directly rather than going through the job, so it passed while the job path was broken. It now exercises the job and asserts no HTTP call was made.

### Two pre-existing concurrency gaps, closed here

Pulled in rather than deferred: the branch raises exposure to both from 12 to 16 refreshes/account/day, and they sit in the method it modifies.

- **The lock was the same length as the request it protects.** `Cache::lock(..., 30)` against the HTTP client's 30s default read timeout, plus 10s connect, and no refresh method set its own. Bluesky is the ceiling with two sequential calls. Named the TTL (`ConnectionVerifier::REFRESH_LOCK_SECONDS`), set it past that, and a test asserts the invariant so a future slower refresh can't quietly break it.
- **`RefreshSocialToken` wasn't unique.** `RefreshExpiringTokens` re-selects an account until `token_expires_at` moves, which only happens once the job runs — so a backlogged queue stacked one job per tick, each rotating a single-use refresh_token again for nothing. Keyed by account, matching `VerifyUpcomingPostConnections`.

### Provider behaviour, verified against official docs

| Provider | Access TTL | Refresh rotates? | Matches our code |
|---|---|---|---|
| **X** | **2h**, stated explicitly | **Yes — single-use** | ✅ `defaultTokenTtlSeconds()` = 7200 |
| **Bluesky** | 2h (hardcoded) | **Yes** — `refreshJwt` is a required output field | ✅ |
| **TikTok** | 24h / refresh 365d | "may be different — use the newly-returned token" | ✅ |
| **LinkedIn** | 60d / refresh 365d | **No** — same token, original TTL kept | ✅ |
| **Google (YouTube)** | — | **No** rotation on refresh | ✅ |

This corrected an error the branch introduced: a docblock claimed **LinkedIn** single-uses its refresh token. Its docs say the opposite. Now reads **X and Bluesky**, which is what the specs describe.

Two risk numbers gained documented bounds: Bluesky's `createSession` is rate-limited per handle at **30/5min and 300/day**, far above our 16 attempts/day; and Google doesn't rotate, so YouTube's 24 → 48 refreshes carry **no single-use risk at all**.

### Residual risk

`refreshXToken` makes the HTTP call and the `$account->update()` as two steps with `$tries = 1`. A worker death in that gap loses the new pair while the provider has already invalidated the old one — the connection is unrecoverable and the user must reconnect.

**Pre-existing, and irreducible**: none of the five provider specs offers any way to acknowledge receipt of a rotated token. What this branch controls is how often we enter the window — **12 → 16 refreshes/account/day (+33%)**, now bounded to one per account per cycle regardless of queue state.

Only X and Bluesky are exposed (single-use rotation). TikTok is unchanged at 1/day; YouTube, Pinterest and LinkedIn don't rotate.

If that matters more than the ~$0.45/account/day, narrowing the lead in `RefreshExpiringTokens` from 30 to ~5 minutes brings it to ~12.5/day, at the cost of less headroom for queue backlog. Not done without a decision.

### Behaviour vs. `main`, case by case

| Case | `main` | branch |
|---|---|---|
| Healthy account | Connected | Connected |
| Refresh rejected, access token alive | Connected | Connected |
| No `refresh_token` stored, access token alive | Connected | Connected |
| Concurrent refresh rotated the pair | Connected | Connected |
| Refresh rejected, access token dead | TokenExpired | TokenExpired |
| Platform down (5xx / network) | unchanged | unchanged |
| Meta rate-limit on Instagram extension | Connected | Connected |

One case differs by design: a legacy row on a no-refresh platform (Facebook, Mastodon, Telegram, Discord) that carries a `token_expires_at`. `main` verifies it **every 15 minutes forever** — 96 wasted calls/day, since nothing ever moves its expiry. Here it's a no-op, and detection moves to the daily sweep (24h instead of 15 min). Those platforms store `null` at connect, so this only concerns hypothetical old data.

## Part 2 — the analytics double read

`XAnalytics::getMetrics` fetched the account's timeline for post ids, then looked the **same ids** up again through `GET /2/tweets`, purely to read the `public_metrics` the first request could have returned. The timeline call asked for `start_time`, `end_time` and `max_results` — never `tweet.fields`.

Both endpoints bill per Post returned. One analytics load for an account with 250 posts in range:

| | HTTP round-trips | Posts returned by the API |
|---|---|---|
| `main` | **6** | the same 250, read **twice** |
| branch | **3** | 250, once |

**This one probably doesn't save dollars, and it's worth saying so.** X deduplicates a resource within a 24-hour UTC window, so the second read of an id already read that day isn't charged again. What it buys is half the round-trips on a user-facing page, half the rate-limit consumption for the same answer, and no longer resting 250 resources' worth of billing per load on a guarantee the docs explicitly call soft ("may result in resources not being deduplicated").

Behaviour is unchanged: same totals, same 5-page ceiling, same empty result when nothing was posted in range. The two helpers collapse into one paginated pass that sums metrics as pages arrive, and the page cap becomes a named constant — it bounds what one load can cost as much as how long it takes, which a bare `5` didn't say.

## Tests

**3767 passed, 1 skipped.** Pint clean.

19 tests on `RefreshSocialToken`, 10 on `VerifyWorkspaceConnections`, and the first 3 for `XAnalytics::getMetrics` — it had none: metrics come from the timeline instead of a second lookup, the timeline request asks for `public_metrics`, and metrics accumulate across paginated pages. New coverage includes: refresh renews without a billed read; a successful refresh stamps `last_verified_at`; a refresh whose follow-up verify fails does **not**; an empty access token in a 200 does not; a lock-skipped refresh does not; a platform with nothing to refresh does not; a rejected refresh doesn't disconnect a working account; no `refresh_token` doesn't either; a rejected refresh **does** disconnect once the access token is dead too; a lost rotation race falls back to the winner's token; a rejected refresh isn't re-sent before the access token is checked; the lock outlives the slowest possible refresh; a backlogged queue can't stack duplicate jobs.

Two existing tests were rewritten to assert the new policy rather than the old one — `refresh job routes through verify (access-token-first) not refreshToken`, and `proactive refresh does NOT rotate the X refresh token while the access token still works`. The concern behind the original policy is still guarded: rotation must leave the account `Connected`.

## Not in this PR

- **Analytics can still pull up to 500 posts** (5 pages × 100) at $0.005 each, and `since`/`until` come straight off the request without validation (`AnalyticsController.php:72`), capped at 100 days inside the service. For a heavy poster on a long range that's $2.50 per UTC day, per account. Reading fewer posts changes what the numbers mean, so it's a product decision rather than a cleanup.
- **Bluesky's `token_expires_at` is hardcoded** to `addHours(2)` in `BlueskyController.php:94` and in `refreshBlueskyToken`, rather than read from the `accessJwt`'s `exp` claim. Pre-existing; the real value is unverified.
- **`Post: Create (with URL)` costs $0.20** vs $0.015 without — 13× — and is untracked. For a scheduling product where most posts carry a link, this may well be the larger share of the bill. The Developer Console's by-endpoint breakdown settles it.
