### PR TITLE
fix(instagram): request `views` instead of retired `plays` for Reels

### DIFF
--- a/app/Services/Social/InstagramAnalytics.php
+++ b/app/Services/Social/InstagramAnalytics.php
@@ -53,7 +53,7 @@ class InstagramAnalytics
         // Per-post metric set differs by content type. Reels/Stories expose
         // different fields than feed posts. Pick the right set per type.
         $metrics = match ($postPlatform->content_type) {
-            ContentType::InstagramReel => 'reach,likes,comments,shares,saved,plays',
+            ContentType::InstagramReel => 'reach,likes,comments,shares,saved,views',
             ContentType::InstagramStory => 'reach,impressions,replies',
             default => 'reach,likes,comments,shares,saved,total_interactions',
         };


### PR DESCRIPTION
Instagram Reels currently report **no metrics at all**, because the per-post insights request asks for `plays`.

Meta retired `plays` from Instagram media insights in Graph API v25. It is not ignored — including it makes the *entire* request fail, so the response never carries the other metrics either (`reach`, `likes`, `comments`, `shares`, `saved`). The failure surfaces as an unsupported/error result rather than partial data, which makes it easy to mistake for "Meta has not populated the numbers yet".

`views` is the documented replacement and lives on the same edge, so this is a drop-in rename.

### How I verified

Probing the media insights edge on a live Business account against v25:

- with `plays` → error response, whose message enumerates the allowed metric set
- that set contains `views` and no longer contains `plays`
- swapping the name → the request succeeds and returns the full set

Running this in production since 2026-08-04; Reel metrics have been flowing since (previously every Reel came back empty).

Feed posts have a separate but related problem with the retired `post_impressions*` family — I will send that as its own PR to keep this one reviewable.