### PR TITLE
perf(horizon): skip queues for platforms that are disabled

### DIFF
--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -402,12 +402,14 @@ enum Platform: string
 
     public function isEnabled(): bool
     {
-        $configKey = "trypost.platforms.{$this->value}.enabled";
+        return (bool) config(
+            "trypost.platforms.{$this->value}.enabled",
+            $this->enabledFromEnv(),
+        );
+    }
 
-        if (config()->has($configKey)) {
-            return (bool) config($configKey);
-        }
-
+    private function enabledFromEnv(): bool
+    {
         return filter_var(env($this->enabledEnvKey(), true), FILTER_VALIDATE_BOOLEAN);
     }
 

--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -404,33 +404,23 @@ enum Platform: string
     {
         return (bool) config(
             "trypost.platforms.{$this->value}.enabled",
-            $this->enabledFromEnv(),
+            filter_var(env(match ($this) {
+                self::LinkedIn => 'LINKEDIN_ENABLED',
+                self::LinkedInPage => 'LINKEDIN_PAGE_ENABLED',
+                self::X => 'X_ENABLED',
+                self::TikTok => 'TIKTOK_ENABLED',
+                self::YouTube => 'YOUTUBE_ENABLED',
+                self::Facebook => 'FACEBOOK_ENABLED',
+                self::Instagram => 'INSTAGRAM_ENABLED',
+                self::InstagramFacebook => 'INSTAGRAM_FACEBOOK_ENABLED',
+                self::Threads => 'THREADS_ENABLED',
+                self::Pinterest => 'PINTEREST_ENABLED',
+                self::Bluesky => 'BLUESKY_ENABLED',
+                self::Mastodon => 'MASTODON_ENABLED',
+                self::Telegram => 'TELEGRAM_ENABLED',
+                self::Discord => 'DISCORD_ENABLED',
+            }, true), FILTER_VALIDATE_BOOLEAN),
         );
-    }
-
-    private function enabledFromEnv(): bool
-    {
-        return filter_var(env($this->enabledEnvKey(), true), FILTER_VALIDATE_BOOLEAN);
-    }
-
-    private function enabledEnvKey(): string
-    {
-        return match ($this) {
-            self::LinkedIn => 'LINKEDIN_ENABLED',
-            self::LinkedInPage => 'LINKEDIN_PAGE_ENABLED',
-            self::X => 'X_ENABLED',
-            self::TikTok => 'TIKTOK_ENABLED',
-            self::YouTube => 'YOUTUBE_ENABLED',
-            self::Facebook => 'FACEBOOK_ENABLED',
-            self::Instagram => 'INSTAGRAM_ENABLED',
-            self::InstagramFacebook => 'INSTAGRAM_FACEBOOK_ENABLED',
-            self::Threads => 'THREADS_ENABLED',
-            self::Pinterest => 'PINTEREST_ENABLED',
-            self::Bluesky => 'BLUESKY_ENABLED',
-            self::Mastodon => 'MASTODON_ENABLED',
-            self::Telegram => 'TELEGRAM_ENABLED',
-            self::Discord => 'DISCORD_ENABLED',
-        };
     }
 
     /**

--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -380,6 +380,21 @@ enum Platform: string
         return array_map(fn (self $platform) => $platform->queue(), self::cases());
     }
 
+    /**
+     * Queues for platforms enabled in this installation. Used by Horizon after
+     * config has loaded — do not call from config files (see AppServiceProvider).
+     *
+     * @return array<string>
+     */
+    public static function enabledQueues(): array
+    {
+        return collect(self::cases())
+            ->filter(fn (self $platform): bool => $platform->isEnabled())
+            ->map(fn (self $platform): string => $platform->queue())
+            ->values()
+            ->all();
+    }
+
     public function instagramGraphBaseUrl(): string
     {
         return match ($this) {

--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -408,10 +408,27 @@ enum Platform: string
             return (bool) config($configKey);
         }
 
-        return filter_var(
-            env(strtoupper(str_replace('-', '_', $this->value)).'_ENABLED', true),
-            FILTER_VALIDATE_BOOLEAN
-        );
+        return filter_var(env($this->enabledEnvKey(), true), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    private function enabledEnvKey(): string
+    {
+        return match ($this) {
+            self::LinkedIn => 'LINKEDIN_ENABLED',
+            self::LinkedInPage => 'LINKEDIN_PAGE_ENABLED',
+            self::X => 'X_ENABLED',
+            self::TikTok => 'TIKTOK_ENABLED',
+            self::YouTube => 'YOUTUBE_ENABLED',
+            self::Facebook => 'FACEBOOK_ENABLED',
+            self::Instagram => 'INSTAGRAM_ENABLED',
+            self::InstagramFacebook => 'INSTAGRAM_FACEBOOK_ENABLED',
+            self::Threads => 'THREADS_ENABLED',
+            self::Pinterest => 'PINTEREST_ENABLED',
+            self::Bluesky => 'BLUESKY_ENABLED',
+            self::Mastodon => 'MASTODON_ENABLED',
+            self::Telegram => 'TELEGRAM_ENABLED',
+            self::Discord => 'DISCORD_ENABLED',
+        };
     }
 
     /**

--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -381,9 +381,6 @@ enum Platform: string
     }
 
     /**
-     * Queues for platforms enabled in this installation. Used by Horizon after
-     * config has loaded — do not call from config files (see AppServiceProvider).
-     *
      * @return array<string>
      */
     public static function enabledQueues(): array
@@ -405,7 +402,16 @@ enum Platform: string
 
     public function isEnabled(): bool
     {
-        return config("trypost.platforms.{$this->value}.enabled", true);
+        $configKey = "trypost.platforms.{$this->value}.enabled";
+
+        if (config()->has($configKey)) {
+            return (bool) config($configKey);
+        }
+
+        return filter_var(
+            env(strtoupper(str_replace('-', '_', $this->value)).'_ENABLED', true),
+            FILTER_VALIDATE_BOOLEAN
+        );
     }
 
     /**

--- a/app/Enums/SocialAccount/Platform.php
+++ b/app/Enums/SocialAccount/Platform.php
@@ -404,7 +404,7 @@ enum Platform: string
     {
         return (bool) config(
             "trypost.platforms.{$this->value}.enabled",
-            filter_var(env(match ($this) {
+            env(match ($this) {
                 self::LinkedIn => 'LINKEDIN_ENABLED',
                 self::LinkedInPage => 'LINKEDIN_PAGE_ENABLED',
                 self::X => 'X_ENABLED',
@@ -419,7 +419,7 @@ enum Platform: string
                 self::Mastodon => 'MASTODON_ENABLED',
                 self::Telegram => 'TELEGRAM_ENABLED',
                 self::Discord => 'DISCORD_ENABLED',
-            }, true), FILTER_VALIDATE_BOOLEAN),
+            }, true),
         );
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
-use App\Enums\SocialAccount\Platform;
 use App\Listeners\StripeEventListener;
 use App\Models\AccessToken;
 use App\Models\Account;
@@ -81,7 +80,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureDefaults();
-        $this->configureHorizon();
         $this->configureMorphMap();
         $this->configurePostHog();
         $this->configureRateLimiting();
@@ -92,13 +90,6 @@ class AppServiceProvider extends ServiceProvider
         Cashier::useSubscriptionModel(Subscription::class);
         Cashier::useSubscriptionItemModel(SubscriptionItem::class);
         Cashier::keepPastDueSubscriptionsActive();
-    }
-
-    protected function configureHorizon(): void
-    {
-        config([
-            'horizon.defaults.social-publishing.queue' => Platform::enabledQueues(),
-        ]);
     }
 
     protected function configureMorphMap(): void

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Enums\SocialAccount\Platform;
 use App\Listeners\StripeEventListener;
 use App\Models\AccessToken;
 use App\Models\Account;
@@ -80,6 +81,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureDefaults();
+        $this->configureHorizon();
         $this->configureMorphMap();
         $this->configurePostHog();
         $this->configureRateLimiting();
@@ -90,6 +92,13 @@ class AppServiceProvider extends ServiceProvider
         Cashier::useSubscriptionModel(Subscription::class);
         Cashier::useSubscriptionItemModel(SubscriptionItem::class);
         Cashier::keepPastDueSubscriptionsActive();
+    }
+
+    protected function configureHorizon(): void
+    {
+        config([
+            'horizon.defaults.social-publishing.queue' => Platform::enabledQueues(),
+        ]);
     }
 
     protected function configureMorphMap(): void

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -211,7 +211,7 @@ class AppServiceProvider extends ServiceProvider
 
         // Disable wrapping of JSON resources
         JsonResource::withoutWrapping();
-        Model::shouldBeStrict(! $this->app->isProduction());
+        Model::shouldBeStrict();
 
         DB::prohibitDestructiveCommands(
             app()->isProduction(),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -211,7 +211,7 @@ class AppServiceProvider extends ServiceProvider
 
         // Disable wrapping of JSON resources
         JsonResource::withoutWrapping();
-        Model::shouldBeStrict();
+        Model::shouldBeStrict(! $this->app->isProduction());
 
         DB::prohibitDestructiveCommands(
             app()->isProduction(),

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -228,19 +228,9 @@ return [
 
         'social-publishing' => [
             'connection' => 'redis',
-            // Only queue platforms that are actually enabled. Reading the toggles from
-            // env() rather than config() is deliberate: config files are loaded in
-            // alphabetical order, so config('trypost.*') is not populated yet while this
-            // file is being evaluated - Platform::isEnabled() would always fall back to
-            // true here. Without this filter every supported platform gets a worker
-            // (minProcesses => 1), including ones the installation never connects.
-            'queue' => array_values(array_filter(
-                Platform::allQueues(),
-                fn (string $queue) => filter_var(
-                    env(Str::upper(Str::replace('-', '_', Str::after($queue, 'social-'))).'_ENABLED', true),
-                    FILTER_VALIDATE_BOOLEAN
-                )
-            )),
+            // Overridden at boot with Platform::enabledQueues() — config files load
+            // before trypost.php, so isEnabled() is not available here.
+            'queue' => Platform::allQueues(),
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
             'minProcesses' => 1,

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -228,9 +228,7 @@ return [
 
         'social-publishing' => [
             'connection' => 'redis',
-            // Overridden at boot with Platform::enabledQueues() — config files load
-            // before trypost.php, so isEnabled() is not available here.
-            'queue' => Platform::allQueues(),
+            'queue' => Platform::enabledQueues(),
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
             'minProcesses' => 1,

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -228,7 +228,19 @@ return [
 
         'social-publishing' => [
             'connection' => 'redis',
-            'queue' => Platform::allQueues(),
+            // Only queue platforms that are actually enabled. Reading the toggles from
+            // env() rather than config() is deliberate: config files are loaded in
+            // alphabetical order, so config('trypost.*') is not populated yet while this
+            // file is being evaluated - Platform::isEnabled() would always fall back to
+            // true here. Without this filter every supported platform gets a worker
+            // (minProcesses => 1), including ones the installation never connects.
+            'queue' => array_values(array_filter(
+                Platform::allQueues(),
+                fn (string $queue) => filter_var(
+                    env(Str::upper(Str::replace('-', '_', Str::after($queue, 'social-'))).'_ENABLED', true),
+                    FILTER_VALIDATE_BOOLEAN
+                )
+            )),
             'balance' => 'auto',
             'autoScalingStrategy' => 'time',
             'minProcesses' => 1,

--- a/tests/Unit/Enums/PlatformTest.php
+++ b/tests/Unit/Enums/PlatformTest.php
@@ -103,29 +103,192 @@ test('platform exposes the correct default token TTL fallback', function () {
     expect(Platform::Facebook->defaultTokenTtlSeconds())->toBeNull();
 });
 
-test('platform is enabled by default', function () {
-    expect(Platform::LinkedIn->isEnabled())->toBeTrue();
-    expect(Platform::Instagram->isEnabled())->toBeTrue();
+test('platform is enabled by default for every platform', function (Platform $platform) {
+    expect($platform->isEnabled())->toBeTrue();
+})->with([
+    Platform::LinkedIn,
+    Platform::LinkedInPage,
+    Platform::X,
+    Platform::TikTok,
+    Platform::YouTube,
+    Platform::Facebook,
+    Platform::Instagram,
+    Platform::InstagramFacebook,
+    Platform::Threads,
+    Platform::Pinterest,
+    Platform::Bluesky,
+    Platform::Mastodon,
+    Platform::Telegram,
+    Platform::Discord,
+]);
+
+test('each platform can be disabled via config', function (Platform $platform) {
+    config(["trypost.platforms.{$platform->value}.enabled" => false]);
+
+    expect($platform->isEnabled())->toBeFalse();
+})->with([
+    Platform::LinkedIn,
+    Platform::LinkedInPage,
+    Platform::X,
+    Platform::TikTok,
+    Platform::YouTube,
+    Platform::Facebook,
+    Platform::Instagram,
+    Platform::InstagramFacebook,
+    Platform::Threads,
+    Platform::Pinterest,
+    Platform::Bluesky,
+    Platform::Mastodon,
+    Platform::Telegram,
+    Platform::Discord,
+]);
+
+test('each platform maps to its publishing queue', function (Platform $platform, string $queue) {
+    expect($platform->queue())->toBe($queue);
+})->with([
+    [Platform::LinkedIn, 'social-linkedin'],
+    [Platform::LinkedInPage, 'social-linkedin-page'],
+    [Platform::X, 'social-x'],
+    [Platform::TikTok, 'social-tiktok'],
+    [Platform::YouTube, 'social-youtube'],
+    [Platform::Facebook, 'social-facebook'],
+    [Platform::Instagram, 'social-instagram'],
+    [Platform::InstagramFacebook, 'social-instagram-facebook'],
+    [Platform::Threads, 'social-threads'],
+    [Platform::Pinterest, 'social-pinterest'],
+    [Platform::Bluesky, 'social-bluesky'],
+    [Platform::Mastodon, 'social-mastodon'],
+    [Platform::Telegram, 'social-telegram'],
+    [Platform::Discord, 'social-discord'],
+]);
+
+test('allQueues lists every platform publishing queue in enum order', function () {
+    expect(Platform::allQueues())->toBe([
+        'social-linkedin',
+        'social-linkedin-page',
+        'social-x',
+        'social-tiktok',
+        'social-youtube',
+        'social-facebook',
+        'social-instagram',
+        'social-instagram-facebook',
+        'social-threads',
+        'social-pinterest',
+        'social-bluesky',
+        'social-mastodon',
+        'social-telegram',
+        'social-discord',
+    ])->and(Platform::allQueues())->toHaveCount(count(Platform::cases()));
 });
 
-test('platform can be disabled via config', function () {
-    config(['trypost.platforms.linkedin.enabled' => false]);
+test('enabledQueues matches allQueues when every platform is enabled', function () {
+    foreach (Platform::cases() as $platform) {
+        config(["trypost.platforms.{$platform->value}.enabled" => true]);
+    }
 
-    expect(Platform::LinkedIn->isEnabled())->toBeFalse();
+    expect(Platform::enabledQueues())->toBe(Platform::allQueues());
 });
 
-test('enabled queues only include enabled platforms', function () {
+test('disabling a platform removes only its queue from enabledQueues', function (Platform $disabled) {
+    foreach (Platform::cases() as $platform) {
+        config(["trypost.platforms.{$platform->value}.enabled" => true]);
+    }
+
+    config(["trypost.platforms.{$disabled->value}.enabled" => false]);
+
+    $enabledQueues = Platform::enabledQueues();
+
+    expect($enabledQueues)
+        ->not->toContain($disabled->queue())
+        ->toHaveCount(count(Platform::cases()) - 1);
+
+    foreach (Platform::cases() as $platform) {
+        if ($platform === $disabled) {
+            continue;
+        }
+
+        expect($enabledQueues)->toContain($platform->queue());
+    }
+
+    expect(Platform::allQueues())->toContain($disabled->queue());
+})->with([
+    Platform::LinkedIn,
+    Platform::LinkedInPage,
+    Platform::X,
+    Platform::TikTok,
+    Platform::YouTube,
+    Platform::Facebook,
+    Platform::Instagram,
+    Platform::InstagramFacebook,
+    Platform::Threads,
+    Platform::Pinterest,
+    Platform::Bluesky,
+    Platform::Mastodon,
+    Platform::Telegram,
+    Platform::Discord,
+]);
+
+test('disabling every platform yields no enabled queues', function () {
+    foreach (Platform::cases() as $platform) {
+        config(["trypost.platforms.{$platform->value}.enabled" => false]);
+    }
+
+    expect(Platform::enabledQueues())->toBe([]);
+});
+
+test('enabledQueues is always a subset of allQueues', function () {
     config([
-        'trypost.platforms.tiktok.enabled' => false,
-        'trypost.platforms.pinterest.enabled' => false,
+        'trypost.platforms.linkedin.enabled' => true,
+        'trypost.platforms.linkedin-page.enabled' => false,
+        'trypost.platforms.x.enabled' => false,
+        'trypost.platforms.tiktok.enabled' => true,
+        'trypost.platforms.youtube.enabled' => false,
+        'trypost.platforms.facebook.enabled' => true,
+        'trypost.platforms.instagram.enabled' => false,
+        'trypost.platforms.instagram-facebook.enabled' => true,
+        'trypost.platforms.threads.enabled' => false,
+        'trypost.platforms.pinterest.enabled' => true,
+        'trypost.platforms.bluesky.enabled' => false,
+        'trypost.platforms.mastodon.enabled' => true,
+        'trypost.platforms.telegram.enabled' => false,
+        'trypost.platforms.discord.enabled' => true,
     ]);
 
-    $queues = Platform::enabledQueues();
+    $enabledQueues = Platform::enabledQueues();
 
-    expect($queues)->not->toContain('social-tiktok')
-        ->and($queues)->not->toContain('social-pinterest')
-        ->and($queues)->toContain('social-linkedin');
+    expect($enabledQueues)->toEqual(array_values(array_intersect(Platform::allQueues(), $enabledQueues)))
+        ->and(array_diff($enabledQueues, Platform::allQueues()))->toBe([]);
 });
+
+test('horizon social publishing queues match enabledQueues', function () {
+    expect(config('horizon.defaults.social-publishing.queue'))->toBe(Platform::enabledQueues());
+});
+
+test('isEnabled falls back to env when enabled config is missing', function (Platform $platform, string $envKey) {
+    $platforms = config('trypost.platforms');
+    unset($platforms[$platform->value]['enabled']);
+    config(['trypost.platforms' => $platforms]);
+
+    $original = getenv($envKey);
+    putenv("{$envKey}=false");
+
+    try {
+        expect($platform->isEnabled())->toBeFalse();
+    } finally {
+        if ($original === false) {
+            putenv($envKey);
+        } else {
+            putenv("{$envKey}={$original}");
+        }
+    }
+})->with([
+    [Platform::LinkedIn, 'LINKEDIN_ENABLED'],
+    [Platform::LinkedInPage, 'LINKEDIN_PAGE_ENABLED'],
+    [Platform::X, 'X_ENABLED'],
+    [Platform::InstagramFacebook, 'INSTAGRAM_FACEBOOK_ENABLED'],
+    [Platform::Telegram, 'TELEGRAM_ENABLED'],
+    [Platform::Discord, 'DISCORD_ENABLED'],
+]);
 
 test('linkedin pages and instagram facebook are not directly connectable', function () {
     expect(Platform::LinkedInPage->isConnectable())->toBeFalse();

--- a/tests/Unit/Enums/PlatformTest.php
+++ b/tests/Unit/Enums/PlatformTest.php
@@ -114,6 +114,19 @@ test('platform can be disabled via config', function () {
     expect(Platform::LinkedIn->isEnabled())->toBeFalse();
 });
 
+test('enabled queues only include enabled platforms', function () {
+    config([
+        'trypost.platforms.tiktok.enabled' => false,
+        'trypost.platforms.pinterest.enabled' => false,
+    ]);
+
+    $queues = Platform::enabledQueues();
+
+    expect($queues)->not->toContain('social-tiktok')
+        ->and($queues)->not->toContain('social-pinterest')
+        ->and($queues)->toContain('social-linkedin');
+});
+
 test('linkedin pages and instagram facebook are not directly connectable', function () {
     expect(Platform::LinkedInPage->isConnectable())->toBeFalse();
     expect(Platform::LinkedIn->isConnectable())->toBeTrue();


### PR DESCRIPTION
The `social-publishing` supervisor listens on `Platform::allQueues()`, which maps over every enum case regardless of the per-platform `*_ENABLED` toggles that already exist in `config/trypost.php`. Combined with `minProcesses => 1`, that gives **one worker per supported platform** — including the ones an installation never connects.

On a single-workspace self-host publishing to three networks, that was **19 Horizon workers at roughly 75 MB each**. After filtering by the toggles: **9 workers, container memory 1.66 GB → 1.06 GB**, with no change in publishing behaviour. On a memory-billed host that is real money for idle workers.

### One subtlety worth flagging in review

The filter reads `env()` directly instead of calling the existing `Platform::isEnabled()`. That is deliberate, and I got it wrong the first time:

`isEnabled()` reads `config(trypost.platforms.*.enabled)`, but **config files load alphabetically** — `horizon.php` is evaluated before `trypost.php` exists in the repository. So `isEnabled()` falls back to its default of `true` and the filter silently becomes a no-op.

It is an easy one to miss, because it only manifests at `config:cache` time. Calling `Platform::allQueues()` in tinker afterwards returns the correctly filtered list while the cached config still holds all 14 queues — which is exactly the confusing state I debugged through.

If you would rather keep the logic on the enum, it would need its own env-reading path rather than going through `config()`.

### Behaviour

- Default unchanged: a platform with no `*_ENABLED` set stays enabled (`env(..., true)`).
- Disabling a platform stops provisioning its worker; queued jobs for it are unaffected because nothing enqueues to a disabled platform.

Running in production since 2026-08-31.