### PR TITLE
Carry signup attribution into the Stripe subscription

### DIFF
--- a/app/Actions/Billing/StartSubscriptionCheckout.php
+++ b/app/Actions/Billing/StartSubscriptionCheckout.php
@@ -15,7 +15,9 @@ class StartSubscriptionCheckout
      * Create a Stripe Checkout session for the given price and return an Inertia
      * redirect to it. Quantity tracks the account's workspace count. Trial days,
      * optional first-month coupon, and promotion codes come from cashier /
-     * trypost billing env config via ConfigureSubscriptionCheckout.
+     * trypost billing env config via ConfigureSubscriptionCheckout. The owner's
+     * signup attribution and onboarding answers ride along as subscription
+     * metadata, flattened to the strings Stripe accepts.
      */
     public function redirect(Account $account, string $priceId, string $cancelUrl): Response
     {
@@ -24,8 +26,20 @@ class StartSubscriptionCheckout
             'name' => $account->stripeName(),
         ]);
 
+        $owner = $account->owner;
+
         $subscription = $account->newSubscription(Account::SUBSCRIPTION_NAME, $priceId)
-            ->quantity(max(1, $account->workspaces()->count()));
+            ->quantity(max(1, $account->workspaces()->count()))
+            ->withMetadata(array_filter([
+                'utm_source' => $owner?->utm_source,
+                'utm_medium' => $owner?->utm_medium,
+                'utm_campaign' => $owner?->utm_campaign,
+                'utm_term' => $owner?->utm_term,
+                'utm_content' => $owner?->utm_content,
+                'persona' => $owner?->persona?->value,
+                'goals' => implode(',', $owner?->goals ?? []),
+                'referral_source' => $owner?->referral_source?->value,
+            ]));
 
         ConfigureSubscriptionCheckout::apply($subscription, $account);
 

--- a/tests/Unit/Actions/Billing/StartSubscriptionCheckoutTest.php
+++ b/tests/Unit/Actions/Billing/StartSubscriptionCheckoutTest.php
@@ -3,7 +3,10 @@
 declare(strict_types=1);
 
 use App\Actions\Billing\StartSubscriptionCheckout;
+use App\Enums\User\Persona;
+use App\Enums\User\ReferralSource;
 use App\Models\Account;
+use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Cashier\SubscriptionBuilder;
@@ -12,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 uses(RefreshDatabase::class);
 
-test('redirect applies checkout configuration before opening the stripe session', function () {
+test('redirect applies checkout configuration and attribution metadata before opening the stripe session', function () {
     config([
         'trypost.billing.require_card_for_trial' => true,
         'cashier.trial_days' => 8,
@@ -22,11 +25,36 @@ test('redirect applies checkout configuration before opening the stripe session'
 
     $account = Account::factory()->create();
     Workspace::factory()->create(['account_id' => $account->id]);
+    User::factory()->create([
+        'account_id' => $account->id,
+        'utm_source' => 'google',
+        'utm_medium' => 'cpc',
+        'utm_campaign' => 'launch',
+        'utm_term' => 'social scheduler',
+        'utm_content' => 'headline-b',
+        'persona' => Persona::Agency,
+        'goals' => ['grow_audience', 'save_time'],
+        'referral_source' => ReferralSource::ProductHunt,
+    ]);
+    $account->refresh();
 
     $cancelUrl = route('app.welcome');
 
     $builder = Mockery::mock(SubscriptionBuilder::class);
     $builder->shouldReceive('quantity')->once()->with(1)->andReturnSelf();
+    $builder->shouldReceive('withMetadata')
+        ->once()
+        ->with([
+            'utm_source' => 'google',
+            'utm_medium' => 'cpc',
+            'utm_campaign' => 'launch',
+            'utm_term' => 'social scheduler',
+            'utm_content' => 'headline-b',
+            'persona' => 'agency',
+            'goals' => 'grow_audience,save_time',
+            'referral_source' => 'product_hunt',
+        ])
+        ->andReturnSelf();
     $builder->shouldReceive('trialDays')->once()->with(8)->andReturnSelf();
     $builder->shouldReceive('withCoupon')->never();
     $builder->shouldReceive('allowPromotionCodes')->never();
@@ -54,4 +82,35 @@ test('redirect applies checkout configuration before opening the stripe session'
 
     expect($response->headers->get('Location'))->toBe('https://checkout.stripe.test/session')
         ->and($response->getStatusCode())->toBe(Response::HTTP_FOUND);
+});
+
+test('redirect sends no metadata for an account whose owner left every field empty', function () {
+    config([
+        'trypost.billing.require_card_for_trial' => true,
+        'cashier.trial_days' => 8,
+        'cashier.first_month_coupon_id' => '',
+        'cashier.allow_promotion_codes' => false,
+    ]);
+
+    $account = Account::factory()->create();
+    Workspace::factory()->create(['account_id' => $account->id]);
+    User::factory()->create(['account_id' => $account->id]);
+    $account->refresh();
+
+    $cancelUrl = route('app.welcome');
+
+    $builder = Mockery::mock(SubscriptionBuilder::class);
+    $builder->shouldReceive('quantity')->once()->andReturnSelf();
+    $builder->shouldReceive('withMetadata')->once()->with([])->andReturnSelf();
+    $builder->shouldReceive('trialDays')->once()->andReturnSelf();
+    $builder->shouldReceive('checkout')
+        ->once()
+        ->andReturn((object) ['url' => 'https://checkout.stripe.test/session']);
+
+    /** @var Account&MockInterface $accountMock */
+    $accountMock = Mockery::mock($account)->makePartial();
+    $accountMock->shouldReceive('createOrGetStripeCustomer')->once()->andReturnNull();
+    $accountMock->shouldReceive('newSubscription')->once()->andReturn($builder);
+
+    app(StartSubscriptionCheckout::class)->redirect($accountMock, 'price_monthly_test', $cancelUrl);
 });


### PR DESCRIPTION
Every account arrives with the UTM parameters that brought it and the onboarding answers it gave — persona, goals, referral source — and none of it reached Stripe. Revenue lived in one system and the campaign that produced it in another, so answering *"which campaign is actually paying for itself"* meant joining the two by hand on email.

This forwards the account owner's five UTMs plus `persona`, `goals` and `referral_source` as metadata on the Checkout session.

### Subscription metadata, not session metadata

Cashier's `withMetadata()` writes into `subscription_data.metadata` during Checkout, so the values land on the **Stripe Subscription**, not the session.

That distinction matters: a Checkout session expires in 24 hours, while the subscription carries the attribution for as long as the customer does — visible on the subscription in the dashboard, and available to every report built on subscriptions. Attribution on the session would only ever be readable from the `checkout.session.completed` webhook, where we already know the account anyway.

### Shaping the values for Stripe

Stripe metadata holds string key/value pairs, so two columns cannot go through as-is — passing either fails the request outright:

| field | why | stored as |
| --- | --- | --- |
| `persona`, `referral_source` | enum-cast, so the attribute is a `BackedEnum` object | `?->value` — `agency`, `product_hunt` |
| `goals` | JSON column, so the attribute is an array | comma-joined — `grow_audience,save_time` |
| `utm_*` (5) | plain strings | as-is |

Comma-joining `goals` over `goals_0` / `goals_1` or a JSON blob keeps it readable in the Stripe dashboard and filterable.

`array_filter` drops the keys the user never filled in: an absent key reads the same in reporting, and Stripe treats an explicit `null` as a delete instruction. Every read is null-safe, so an account with no owner simply sends no metadata.

### Scope

The ad click IDs sitting next to the UTMs on the users table (`gclid`, `fbclid`, `li_fat_id`, `ttclid`, `rdt_cid`, `epik`) are **deliberately left out**. Worth adding if we ever want to import conversions back into Google or Meta Ads, but that is a separate decision from campaign reporting.

### Tests

`StartSubscriptionCheckoutTest` asserts the exact payload reaching `withMetadata()` — the full mapping in one case, and `[]` for an owner who filled in nothing.

Full suite green: 4062 passed.