### PR TITLE
Send the ad click IDs to Stripe alongside the UTM parameters

### DIFF
--- a/app/Actions/Billing/StartSubscriptionCheckout.php
+++ b/app/Actions/Billing/StartSubscriptionCheckout.php
@@ -6,6 +6,7 @@ namespace App\Actions\Billing;
 
 use App\Models\Account;
 use App\Support\Billing\ConfigureSubscriptionCheckout;
+use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -16,8 +17,11 @@ class StartSubscriptionCheckout
      * redirect to it. Quantity tracks the account's workspace count. Trial days,
      * optional first-month coupon, and promotion codes come from cashier /
      * trypost billing env config via ConfigureSubscriptionCheckout. The owner's
-     * signup attribution and onboarding answers ride along as subscription
-     * metadata, flattened to the strings Stripe accepts.
+     * signup attribution -- UTM parameters and ad click IDs -- and onboarding
+     * answers ride along as subscription metadata, flattened to the strings
+     * Stripe stores and cut to the 500 characters it allows per value. Stripe
+     * rejects a longer value outright rather than truncating it, which would
+     * fail the whole checkout: https://docs.stripe.com/api/metadata
      */
     public function redirect(Account $account, string $priceId, string $cancelUrl): Response
     {
@@ -28,18 +32,29 @@ class StartSubscriptionCheckout
 
         $owner = $account->owner;
 
+        $metadata = array_filter([
+            'utm_source' => $owner?->utm_source,
+            'utm_medium' => $owner?->utm_medium,
+            'utm_campaign' => $owner?->utm_campaign,
+            'utm_term' => $owner?->utm_term,
+            'utm_content' => $owner?->utm_content,
+            'gclid' => $owner?->gclid,
+            'fbclid' => $owner?->fbclid,
+            'li_fat_id' => $owner?->li_fat_id,
+            'ttclid' => $owner?->ttclid,
+            'rdt_cid' => $owner?->rdt_cid,
+            'epik' => $owner?->epik,
+            'persona' => $owner?->persona?->value,
+            'goals' => implode(',', $owner?->goals ?? []),
+            'referral_source' => $owner?->referral_source?->value,
+        ]);
+
         $subscription = $account->newSubscription(Account::SUBSCRIPTION_NAME, $priceId)
             ->quantity(max(1, $account->workspaces()->count()))
-            ->withMetadata(array_filter([
-                'utm_source' => $owner?->utm_source,
-                'utm_medium' => $owner?->utm_medium,
-                'utm_campaign' => $owner?->utm_campaign,
-                'utm_term' => $owner?->utm_term,
-                'utm_content' => $owner?->utm_content,
-                'persona' => $owner?->persona?->value,
-                'goals' => implode(',', $owner?->goals ?? []),
-                'referral_source' => $owner?->referral_source?->value,
-            ]));
+            ->withMetadata(array_map(
+                fn (string $value): string => Str::limit($value, 500, ''),
+                $metadata,
+            ));
 
         ConfigureSubscriptionCheckout::apply($subscription, $account);
 

--- a/tests/Unit/Actions/Billing/StartSubscriptionCheckoutTest.php
+++ b/tests/Unit/Actions/Billing/StartSubscriptionCheckoutTest.php
@@ -32,6 +32,12 @@ test('redirect applies checkout configuration and attribution metadata before op
         'utm_campaign' => 'launch',
         'utm_term' => 'social scheduler',
         'utm_content' => 'headline-b',
+        'gclid' => 'Cj0KCQgclid',
+        'fbclid' => 'IwAR0fbclid',
+        'li_fat_id' => '9f2li-fat-id',
+        'ttclid' => 'E.C.Pttclid',
+        'rdt_cid' => 'rdt-cid-value',
+        'epik' => 'dj0yepik',
         'persona' => Persona::Agency,
         'goals' => ['grow_audience', 'save_time'],
         'referral_source' => ReferralSource::ProductHunt,
@@ -50,6 +56,12 @@ test('redirect applies checkout configuration and attribution metadata before op
             'utm_campaign' => 'launch',
             'utm_term' => 'social scheduler',
             'utm_content' => 'headline-b',
+            'gclid' => 'Cj0KCQgclid',
+            'fbclid' => 'IwAR0fbclid',
+            'li_fat_id' => '9f2li-fat-id',
+            'ttclid' => 'E.C.Pttclid',
+            'rdt_cid' => 'rdt-cid-value',
+            'epik' => 'dj0yepik',
             'persona' => 'agency',
             'goals' => 'grow_audience,save_time',
             'referral_source' => 'product_hunt',
@@ -113,4 +125,39 @@ test('redirect sends no metadata for an account whose owner left every field emp
     $accountMock->shouldReceive('newSubscription')->once()->andReturn($builder);
 
     app(StartSubscriptionCheckout::class)->redirect($accountMock, 'price_monthly_test', $cancelUrl);
+});
+
+test('redirect cuts an oversized click id to the stripe metadata limit', function () {
+    config([
+        'trypost.billing.require_card_for_trial' => true,
+        'cashier.trial_days' => 8,
+        'cashier.first_month_coupon_id' => '',
+        'cashier.allow_promotion_codes' => false,
+    ]);
+
+    $account = Account::factory()->create();
+    Workspace::factory()->create(['account_id' => $account->id]);
+    User::factory()->create([
+        'account_id' => $account->id,
+        'fbclid' => str_repeat('a', 900),
+    ]);
+    $account->refresh();
+
+    $builder = Mockery::mock(SubscriptionBuilder::class);
+    $builder->shouldReceive('quantity')->once()->andReturnSelf();
+    $builder->shouldReceive('withMetadata')
+        ->once()
+        ->with(['fbclid' => str_repeat('a', 500)])
+        ->andReturnSelf();
+    $builder->shouldReceive('trialDays')->once()->andReturnSelf();
+    $builder->shouldReceive('checkout')
+        ->once()
+        ->andReturn((object) ['url' => 'https://checkout.stripe.test/session']);
+
+    /** @var Account&MockInterface $accountMock */
+    $accountMock = Mockery::mock($account)->makePartial();
+    $accountMock->shouldReceive('createOrGetStripeCustomer')->once()->andReturnNull();
+    $accountMock->shouldReceive('newSubscription')->once()->andReturn($builder);
+
+    app(StartSubscriptionCheckout::class)->redirect($accountMock, 'price_monthly_test', route('app.welcome'));
 });


### PR DESCRIPTION
Follow-up to #322, which sent the UTM parameters and onboarding answers to the Stripe subscription but left the ad click IDs behind.

UTM parameters say which *campaign* a customer came from. The click ID identifies the *individual click* — which is what Google Ads and Meta need to match a paying subscription back to the exact ad that produced it. Without it the attribution stops at campaign level and offline conversion import is not possible.

Signup already captures one per network, so this is purely a forwarding change:

| column | network |
| --- | --- |
| `gclid` | Google |
| `fbclid` | Meta |
| `li_fat_id` | LinkedIn |
| `ttclid` | TikTok |
| `rdt_cid` | Reddit |
| `epik` | Pinterest |

Every key is spelled out at the call site rather than mapped over a constant, so what reaches Stripe can be read in one place without following an indirection.

### The 500-character cut is load-bearing here

Stripe caps a metadata value at 500 characters and **rejects the request** rather than truncating. A rejected request means the checkout session is never created and the customer cannot subscribe at all — silent lost revenue, triggered by whatever happened to be in their signup URL.

In #322 this could not happen: the UTM columns are `varchar(255)`. The click IDs are deliberately `text` — [`a3b85d19`](https://github.com/trypostit/trypost/commit/a3b85d19) established that truncating them at 255 destroys their value — so they are unbounded and the ceiling is now reachable. Cutting at 500 on the way out trades a truncated click ID for a checkout that still works.

### Not included: X / Twitter

There is no `twclid` column, and nothing captures it at signup. Adding it is a migration plus capture wiring, not a metadata change, so it is out of scope here — worth its own PR if we run X ads.

### Tests

`StartSubscriptionCheckoutTest` covers the full payload including all six click IDs, an owner with nothing filled in (`[]`), and a 900-character `fbclid` arriving at Stripe as exactly 500.

Full suite green: 4063 passed.