### PR TITLE
fix(auth): show Privacy/ToS footer links on login too, point at madevisible.io

### DIFF
--- a/PATCHES.md
+++ b/PATCHES.md
@@ -1,0 +1,36 @@
+# Lokale Patches · trypost (Fork)
+
+Privater Fork `Cryptoom/trypost` (origin). Upstream `trypostit/trypost` als Remote `upstream`.
+Angelegt 2026-08-25 als Infrastruktur-Vorbereitung (noch KEIN aktiver Patch), Muster identisch
+zu `~/voice-clone/whatsapp-mcp/PATCHES.md` und dem telegram-mcp-Fork.
+
+Lizenz-Hinweis (wichtig, anders als bei den anderen beiden Forks): TryPost ist **AGPL-3.0**,
+nicht MIT/Apache. AGPL hat Netzwerk-Copyleft: sobald eine modifizierte Version selbst gehostet
+UND von Dritten (echten Kunden-Workspaces, nicht nur Digital Mind Agency/Jasmin intern) genutzt
+wird, muss diesen Dritten der modifizierte Quellcode zugaenglich gemacht werden (z.B. Link im
+Footer/Impressum zum Fork-Repo). Fuer den aktuellen Piloten (nur wir + Jasmin) unkritisch, vor
+dem ersten echten Kunden-Workspace mit gepatchtem TryPost aber Pflicht-Punkt.
+
+Update-Flow: `git fetch upstream && git merge upstream/main`, danach jeden Patch unten anhand
+seines Marker-Strings gegenpruefen (`grep` reicht meist), erst dann `docker compose up -d --build`
+auf web02 (Update-Klasse B/C-Aequivalent, siehe `~/.claude/rules/web02-docker-updates.md`, dort
+noch nachtragen sobald der erste echte Patch aktiv ist).
+
+## Aktive Patches
+
+Keine. Diese Datei ist bewusst als leeres Geruest angelegt (Olli-Entscheidung 25.08.2026:
+"Fork jetzt anlegen, Infrastruktur vorbereiten"), damit ein spaeterer Patch (z.B. der
+`is_aigc`-Composer-UI-Toggle aus dem TryPost-Phase-4-Planungs-Pass, falls das GitHub-Issue
+nicht zeitnah beantwortet wird) sofort in der etablierten Struktur landet statt einer neuen.
+
+## Wie ein neuer Patch hier reinkommt
+
+1. Aenderung im Fork machen, committen, Marker-String im Commit-Message + hier dokumentieren
+   (Datei, Zeile/Funktion, WARUM, welcher Marker-String das Wiedererkennen nach einem Merge
+   erlaubt).
+2. `web02`-Deploy: `/opt/trypost` laeuft als lokaler Build aus Git-Checkout (Update-Klasse C,
+   siehe `~/.claude/CLAUDE.md` Docker-Tabelle), NICHT das published Image. Fork-Checkout auf
+   dem Server auf `Cryptoom/trypost` umstellen sobald der erste Patch aktiv wird (aktuell laeuft
+   der Server-Checkout noch gegen upstream, unveraendert).
+3. Nach jedem `git merge upstream/main`: alle Marker-Strings unten gegenpruefen, dieser
+   Abschnitt fasst dann "Stand nach Merge <datum>" analog zum whatsapp-mcp-Muster.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -42,6 +42,20 @@ vorbefuellen) einen manuellen Umweg ueber die UI.
   `brand_color`, Cross-Workspace-Isolation, Ability-Check fuer Member ohne Admin/Owner-Rolle).
 - Bricht bei einem Merge NUR falls upstream `UpdateWorkspaceRequest`, `WorkspaceResource` oder
   die `update`-Ability in `WorkspacePolicy` umbenennt/entfernt, dann Patch-Regeln nachziehen.
+- **Deployed** 25.08.2026: `/opt/trypost` auf web02 laeuft seit diesem Patch auf dem Fork-Remote
+  `Cryptoom/trypost` (vorher `trypostit/trypost` upstream), `docker compose up -d --build`
+  erfolgreich, live verifiziert (Klasse instanziierbar im Produktions-Container).
+
+## Geprueft und NICHT gepatcht: is_aigc-Composer-Toggle (25.08.2026)
+
+Der urspruenglich fuer diesen Fork geplante Patch (TikTok-`is_aigc`-Toggle im Post-Composer,
+fuer die KI-Kennzeichnungs-Pflicht) ist **obsolet**: das Feature existiert bereits vollstaendig
+upstream (`resources/js/components/posts/editor/TikTokSettings.vue`, Checkbox `isAigc`;
+`app/Support/PostPlatformMetaRules.php`, `platforms.*.meta.is_aigc`; `TikTokPublisher.php`,
+setzt `$postInfo['is_aigc']`; auch im MCP `CreatePostTool.php`). Kein Patch noetig. Meta/
+Instagram und YouTube haben kein aequivalentes API-Feld (nur Checklisten-Eintrag), das bleibt
+eine offene Luecke, aber kein Fork-Patch-Kandidat solange die Plattformen selbst kein API-Feld
+anbieten.
 
 ## Wie ein neuer Patch hier reinkommt
 
@@ -49,8 +63,8 @@ vorbefuellen) einen manuellen Umweg ueber die UI.
    (Datei, Zeile/Funktion, WARUM, welcher Marker-String das Wiedererkennen nach einem Merge
    erlaubt).
 2. `web02`-Deploy: `/opt/trypost` laeuft als lokaler Build aus Git-Checkout (Update-Klasse C,
-   siehe `~/.claude/CLAUDE.md` Docker-Tabelle), NICHT das published Image. Fork-Checkout auf
-   dem Server auf `Cryptoom/trypost` umstellen sobald der erste Patch aktiv wird (aktuell laeuft
-   der Server-Checkout noch gegen upstream, unveraendert).
+   siehe `~/.claude/CLAUDE.md` Docker-Tabelle), NICHT das published Image. Seit Patch 1
+   (25.08.2026) laeuft der Server-Checkout gegen `Cryptoom/trypost` (Fork), nicht mehr gegen
+   upstream.
 3. Nach jedem `git merge upstream/main`: alle Marker-Strings unten gegenpruefen, dieser
    Abschnitt fasst dann "Stand nach Merge <datum>" analog zum whatsapp-mcp-Muster.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -46,6 +46,54 @@ vorbefuellen) einen manuellen Umweg ueber die UI.
   `Cryptoom/trypost` (vorher `trypostit/trypost` upstream), `docker compose up -d --build`
   erfolgreich, live verifiziert (Klasse instanziierbar im Produktions-Container).
 
+### Patch 2 · madevisible-brand-token-reskin
+
+Ersetzt die komplette upstream Gumroad-Optik (warmes Cream, Ink-Border, Violett-Akzent,
+Figtree/Instrument-Serif, harte Offset-Shadows) in der `:root`-Deklaration durch die
+madevisible.io-Brand-Tokens (tiefes Teal-Primary, Navy-Text, Gold-Akzent, weiche getoente
+Shadows, Geist-Font-Stack). Concept-Only-Reskin, damit App und die madevisible.io-Kunden-Instanz
+optisch zusammengehoeren.
+
+- **Datei**: `resources/css/app.css`, die `:root`-Deklaration (aktuell Zeilen ca. 16-80).
+- **Marker-Strings zum Wiedererkennen nach `git merge upstream/main`**: die konkreten
+  Hex-Werte `#0c6e6d` (`--primary`/`--ring`/`--sidebar-primary`), `#0a2540` (`--foreground`),
+  `#c99a5c` (`--accent`) und `#a67c3f` (`--chart-3`, WCAG-korrigiert von urspruenglich `#c99a5c`
+  in Review Round 1). Keiner dieser Werte kommt in der upstream-Fassung vor (dort `#7c3aed`
+  Primary/Violett, `#0a0a0a` Foreground/Ink, `#faf8f5` Background). Ebenso der Kommentar
+  `madevisible.io brand tokens (Mediterranean Light / Premium)` direkt unter `:root {`.
+- **Bruchbedingung**: Upstream aendert dieselbe `:root`-Block-Struktur in `app.css` (neue
+  Variablen, umbenannte Tokens, andere Reihenfolge) und `git merge upstream/main` laeuft
+  **konfliktfrei** durch. Ein konfliktfreier Merge ueberschreibt in diesem Fall die
+  Fork-Farbwerte stillschweigend mit den upstream-Originalwerten, weil beide Seiten dieselben
+  Zeilen anfassen und Git sonst laut einen Konflikt melden wuerde. Nach jedem Merge darum
+  gezielt gegen die obigen Hex-Werte greppen (`grep -c '#0c6e6d' resources/css/app.css`), nicht
+  nur auf einen Merge-Konflikt verlassen.
+- Betrifft NUR `:root` (Light-Theme-Tokens). Ein eventueller `.dark`-Block bleibt unangetastet,
+  falls upstream einen ergaenzt, muesste der Reskin dort nachgezogen werden.
+
+### Patch 3 · sidebar-referral-discord-entfernung
+
+Entfernt die zwei untersten Bottom-Nav-Eintraege der Sidebar ("Earn 30% referral" und "Discord
+community"), auf Ollis ausdruecklichen Wunsch (das TryPost-eigene Affiliate-/Community-Programm
+soll im Digital-Mind-Agency-Weissabel-Kontext nicht auftauchen). Entfernt zugleich die dadurch
+unbenutzten Icon-Imports.
+
+- **Datei**: `resources/js/components/AppSidebar.vue`.
+- **Marker-Strings zum Wiedererkennen nach `git merge upstream/main`**: die Imports
+  `IconBrandDiscord` und `IconGift` (aktuell in der Fork-Fassung NICHT mehr im
+  `@tabler/icons-vue`-Import-Block von `AppSidebar.vue` vorhanden) sowie die beiden
+  Objekt-Eintraege mit `href: 'https://affiliates.trypost.it/'` und
+  `href: 'https://trypost.it/discord'` im `bottomNavItems`-Computed (in der Fork-Fassung
+  entfernt). Der Docs-Link (`https://docs.trypost.it`) und `IconAffiliate` bleiben unveraendert
+  bestehen und sind NICHT Teil dieses Patches.
+- **Bruchbedingung**: Upstream ergaenzt in `bottomNavItems` neue Eintraege oder aendert die
+  Struktur des Arrays (z.B. fuegt selbst wieder einen Referral- oder Community-Link hinzu) und
+  `git merge upstream/main` laeuft konfliktfrei durch, weil der Fork die betroffenen Zeilen
+  bereits geloescht hat und Git keinen Konflikt sieht. Ein solcher Merge kann den
+  Referral-/Discord-Link stillschweigend zurueckbringen. Nach jedem Merge pruefen:
+  `grep -n "trypost.it/discord\|affiliates.trypost.it" resources/js/components/AppSidebar.vue`
+  muss leer bleiben.
+
 ## Geprueft und NICHT gepatcht: is_aigc-Composer-Toggle (25.08.2026)
 
 Der urspruenglich fuer diesen Fork geplante Patch (TikTok-`is_aigc`-Toggle im Post-Composer,

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -18,10 +18,30 @@ noch nachtragen sobald der erste echte Patch aktiv ist).
 
 ## Aktive Patches
 
-Keine. Diese Datei ist bewusst als leeres Geruest angelegt (Olli-Entscheidung 25.08.2026:
-"Fork jetzt anlegen, Infrastruktur vorbereiten"), damit ein spaeterer Patch (z.B. der
-`is_aigc`-Composer-UI-Toggle aus dem TryPost-Phase-4-Planungs-Pass, falls das GitHub-Issue
-nicht zeitnah beantwortet wird) sofort in der etablierten Struktur landet statt einer neuen.
+### Patch 1 · update-workspace-tool
+
+Fuegt ein schreibendes MCP-Tool fuer die Workspace-Brand-Settings hinzu. Upstream hat nur
+`GetWorkspaceTool` (read-only, `#[IsReadOnly]`), keinen API- oder MCP-Weg um `name`,
+`brand_website`, `brand_description`, `brand_voice_traits`, `brand_color`, `background_color`,
+`text_color`, `brand_font`, `image_style` oder `content_language` programmatisch zu setzen. Ohne
+diesen Patch braucht jedes automatisierte Kunden-Onboarding (neuer Workspace, Brand per Skript
+vorbefuellen) einen manuellen Umweg ueber die UI.
+
+- **Dateien**:
+  - `app/Mcp/Tools/Workspace/UpdateWorkspaceTool.php` (neu). Validiert dieselben Regeln wie
+    `App\Http\Requests\App\Workspace\UpdateWorkspaceRequest`, aber PATCH-Semantik (`sometimes`
+    statt `required`, nur uebergebene Felder werden geschrieben). Autorisierung ueber
+    `AuthorizesMcpTool::authorizeCurrentWorkspace($request, 'update', ...)`, spiegelt
+    `WorkspaceController::updateSettings()`.
+  - `app/Mcp/Servers/TryPostServer.php` (Import + Registry-Eintrag unter "Workspace").
+- **Marker-String zum Wiedererkennen nach `git merge upstream/main`**: Klassenname
+  `UpdateWorkspaceTool` (Datei existiert upstream nicht) plus der Registry-Kommentar
+  `// Workspace` in `TryPostServer.php` (dort pruefen ob `UpdateWorkspaceTool::class` noch
+  direkt nach `GetWorkspaceTool::class` steht).
+- **Test**: `tests/Feature/Mcp/WorkspaceToolTest.php` (4 neue Tests: valides Update, ungueltige
+  `brand_color`, Cross-Workspace-Isolation, Ability-Check fuer Member ohne Admin/Owner-Rolle).
+- Bricht bei einem Merge NUR falls upstream `UpdateWorkspaceRequest`, `WorkspaceResource` oder
+  die `update`-Ability in `WorkspacePolicy` umbenennt/entfernt, dann Patch-Regeln nachziehen.
 
 ## Wie ein neuer Patch hier reinkommt
 

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -94,6 +94,47 @@ unbenutzten Icon-Imports.
   `grep -n "trypost.it/discord\|affiliates.trypost.it" resources/js/components/AppSidebar.vue`
   muss leer bleiben.
 
+### Patch 4 · madevisible-legal-footer-links
+
+Grund: TikToks App-Review lehnte "madevisible.io Social" am 04.09.2026 ab, unter anderem weil
+`social.madevisible.io/login` **ueberhaupt keine** Privacy-/ToS-Links zeigte (live per Playwright
+mit frisch gecleartem Cookie-Zustand als echter ausgeloggter Besucher verifiziert). Root-Cause:
+Upstream haengt den einzigen Legal-Footer-Block (`auth.legal`-Uebersetzung) an
+`v-if="!isSelfHosted"` in `Register.vue`, und `Login.vue` hatte den Block gar nicht erst. Unser
+Docker-Deployment laeuft mit `trypost.self_hosted=true` (Betreiber-Modell, nicht Multi-Tenant-
+SaaS wie trypost.it selbst), darum blieb der Footer bei uns immer unsichtbar, upstream-seitig
+vermutlich bewusst so gedacht ("Self-Hoster bringt eigene Legal-Links mit"), was fuer uns aber
+nie zutraf.
+
+- **Dateien**:
+  - `lang/*/auth.php` (alle 16 Locales): der `legal`-String zeigte in JEDER Sprache hart auf
+    `https://trypost.it/terms` und `https://trypost.it/privacy`. Beide URLs auf
+    `https://madevisible.io/agb/` bzw. `https://madevisible.io/privacy/` umgestellt (reiner
+    URL-Tausch, uebersetzter Fliesstext unveraendert). Diese beiden Seiten nennen
+    "madevisible.io Social" seit `Cryptoom/digital-mind-agency#396` explizit beim Namen.
+  - `resources/js/pages/auth/Register.vue`: `v-if="!isSelfHosted"`-Guard auf dem Legal-Footer-Div
+    entfernt (zeigt jetzt immer), dadurch wurde die `isSelfHosted`-Computed-Variable unbenutzt und
+    wurde mitentfernt. `page`/`usePage()` bleiben (weiterhin fuer `hasSocial` gebraucht).
+  - `resources/js/pages/auth/Login.vue`: denselben Legal-Footer-Block (identisches Markup wie
+    `Register.vue`, `v-html="$t('auth.legal')"`) direkt nach dem `</Form>` neu ergaenzt, vorher
+    gab es dort ueberhaupt keinen.
+- **Marker-Strings zum Wiedererkennen nach `git merge upstream/main`**: `madevisible.io` in
+  `lang/en/auth.php`s `legal`-Zeile (kommt upstream nicht vor). In `Login.vue`: das
+  `v-html="$t('auth.legal')"`-Div direkt vor dem schliessenden `</div></AuthBase></template>`
+  (existiert upstream nicht in dieser Datei). In `Register.vue`: Abwesenheit von
+  `v-if="!isSelfHosted"` auf dem Legal-Div (upstream hat es).
+- **Bruchbedingung**: Upstream aendert den `auth.legal`-Text selbst (neue Formulierung, neue
+  Platzhalter) und `git merge upstream/main` ueberschreibt konfliktfrei unsere URL-Werte mit den
+  originalen `trypost.it`-URLs zurueck, weil beide Seiten dieselbe Zeile aendern koennten aber
+  Git bei reinem Text-Unterschied idR einen Konflikt meldet (text-basiertes 3-Way-Merge), pruefen
+  nach jedem Merge trotzdem gezielt: `grep -rn "trypost.it/terms\|trypost.it/privacy" lang/*/auth.php`
+  muss leer bleiben. Ergaenzt upstream `Login.vue`/`Register.vue` selbst einen aehnlichen
+  Legal-Footer oder aendert die `isSelfHosted`-Logik grundlegend, Patch-Platzierung manuell
+  gegenpruefen statt blind erneut einzufuegen.
+- **Test**: keine automatisierten Tests vorhanden (reine Template-/Copy-Aenderung), Verifikation
+  ueber Live-Check nach Deploy (siehe unten).
+- **Deployed**: <Datum nach Merge + `docker compose up -d --build` auf web02 nachtragen>.
+
 ## Geprueft und NICHT gepatcht: is_aigc-Composer-Toggle (25.08.2026)
 
 Der urspruenglich fuer diesen Fork geplante Patch (TikTok-`is_aigc`-Toggle im Post-Composer,

--- a/app/Mcp/Servers/TryPostServer.php
+++ b/app/Mcp/Servers/TryPostServer.php
@@ -35,6 +35,7 @@ use App\Mcp\Tools\SocialAccount\ListPinterestBoardsTool;
 use App\Mcp\Tools\SocialAccount\ListSocialAccountsTool;
 use App\Mcp\Tools\SocialAccount\ToggleSocialAccountTool;
 use App\Mcp\Tools\Workspace\GetWorkspaceTool;
+use App\Mcp\Tools\Workspace\UpdateWorkspaceTool;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Attributes\Icon;
 use Laravel\Mcp\Server\Attributes\Instructions;
@@ -91,6 +92,7 @@ class TryPostServer extends Server
 
         // Workspace
         GetWorkspaceTool::class,
+        UpdateWorkspaceTool::class,
 
         // API Keys
         ListApiKeysTool::class,

--- a/app/Mcp/Tools/Workspace/UpdateWorkspaceTool.php
+++ b/app/Mcp/Tools/Workspace/UpdateWorkspaceTool.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools\Workspace;
+
+use App\Enums\Workspace\BrandFont;
+use App\Enums\Workspace\BrandVoiceTrait;
+use App\Enums\Workspace\ContentLanguage;
+use App\Enums\Workspace\ImageStyle;
+use App\Http\Resources\Api\WorkspaceResource;
+use App\Mcp\Concerns\AuthorizesMcpTool;
+use App\Models\Workspace;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Validation\Rule;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\ResponseFactory;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+
+#[Description('Update the current workspace brand settings (name, website, description, voice traits, colors, font, image style, content language). All fields are optional, only the fields you pass are changed.')]
+class UpdateWorkspaceTool extends Tool
+{
+    use AuthorizesMcpTool;
+
+    public function handle(Request $request): Response|ResponseFactory
+    {
+        $workspace = $this->authorizeCurrentWorkspace(
+            $request,
+            'update',
+            'Not authorized to update this workspace.',
+        );
+
+        if (! $workspace instanceof Workspace) {
+            return $workspace;
+        }
+
+        $hex = ['nullable', 'string', 'regex:/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/'];
+
+        $validated = $request->validate([
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'brand_website' => ['sometimes', 'nullable', 'url', 'max:255'],
+            'brand_description' => ['sometimes', 'nullable', 'string', 'max:2000'],
+            'brand_voice_traits' => ['sometimes', 'nullable', 'array'],
+            'brand_voice_traits.*' => ['string', Rule::enum(BrandVoiceTrait::class)],
+            'brand_color' => ['sometimes', ...$hex],
+            'background_color' => ['sometimes', ...$hex],
+            'text_color' => ['sometimes', ...$hex],
+            'brand_font' => ['sometimes', 'required', 'string', Rule::in(BrandFont::values())],
+            'image_style' => ['sometimes', 'required', 'string', Rule::in(ImageStyle::values())],
+            'content_language' => ['sometimes', 'string', Rule::in(ContentLanguage::values())],
+        ]);
+
+        if (array_key_exists('brand_voice_traits', $validated) && $validated['brand_voice_traits'] !== null) {
+            $validated['brand_voice_traits'] = BrandVoiceTrait::coerce($validated['brand_voice_traits']);
+        }
+
+        // PATCH semantics: only the fillable fields the caller actually passed
+        // are written. Mirrors UpdateWorkspaceRequest's field set minus
+        // logo_url (logo upload has its own dedicated flow, not brand settings).
+        $payload = array_intersect_key($validated, array_flip($workspace->getFillable()));
+
+        if ($payload !== []) {
+            $workspace->update($payload);
+        }
+
+        return Response::structured((new WorkspaceResource($workspace))->resolve());
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'name' => $schema->string()->description('Workspace display name.'),
+            'brand_website' => $schema->string()->description('Brand website URL.'),
+            'brand_description' => $schema->string()->description('Brand description, up to 2000 characters.'),
+            'brand_voice_traits' => $schema->array()
+                ->items($schema->string()->enum(BrandVoiceTrait::values()))
+                ->description('Brand voice traits (replaces the existing set). See the grouped trait list for single-select spectrum groups vs additive style traits.'),
+            'brand_color' => $schema->string()->description('Hex color code (e.g. #FF5733).'),
+            'background_color' => $schema->string()->description('Hex color code (e.g. #FFFFFF).'),
+            'text_color' => $schema->string()->description('Hex color code (e.g. #111111).'),
+            'brand_font' => $schema->string()->enum(BrandFont::values())->description('Brand font family name.'),
+            'image_style' => $schema->string()->enum(ImageStyle::values())->description('AI image generation style.'),
+            'content_language' => $schema->string()->enum(ContentLanguage::values())->description('Content language code (e.g. "en", "de").'),
+        ];
+    }
+}

--- a/lang/ar/auth.php
+++ b/lang/ar/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'مرحبًا بك في TryPost! لقد بدأت فترتك التجريبية.',
     ],
 
-    'legal' => 'بمتابعتك، فإنك توافق على <a href="https://trypost.it/terms" target="_blank">شروط الخدمة</a> و<a href="https://trypost.it/privacy" target="_blank">سياسة الخصوصية</a>.',
+    'legal' => 'بمتابعتك، فإنك توافق على <a href="https://madevisible.io/agb/" target="_blank">شروط الخدمة</a> و<a href="https://madevisible.io/privacy/" target="_blank">سياسة الخصوصية</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/de/auth.php
+++ b/lang/de/auth.php
@@ -24,7 +24,7 @@ return [
         'welcome_trial' => 'Willkommen bei TryPost! Deine Testphase hat begonnen.',
     ],
 
-    'legal' => 'Indem du fortfährst, stimmst du unseren <a href="https://trypost.it/terms" target="_blank">Nutzungsbedingungen</a> und unserer <a href="https://trypost.it/privacy" target="_blank">Datenschutzerklärung</a> zu.',
+    'legal' => 'Indem du fortfährst, stimmst du unseren <a href="https://madevisible.io/agb/" target="_blank">Nutzungsbedingungen</a> und unserer <a href="https://madevisible.io/privacy/" target="_blank">Datenschutzerklärung</a> zu.',
 
     'slides' => [
         'calendar' => [

--- a/lang/el/auth.php
+++ b/lang/el/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Καλώς ήρθατε στο TryPost! Η δοκιμαστική σας περίοδος ξεκίνησε.',
     ],
 
-    'legal' => 'Συνεχίζοντας, συμφωνείτε με τους <a href="https://trypost.it/terms" target="_blank">Όρους Χρήσης</a> και την <a href="https://trypost.it/privacy" target="_blank">Πολιτική Απορρήτου</a> μας.',
+    'legal' => 'Συνεχίζοντας, συμφωνείτε με τους <a href="https://madevisible.io/agb/" target="_blank">Όρους Χρήσης</a> και την <a href="https://madevisible.io/privacy/" target="_blank">Πολιτική Απορρήτου</a> μας.',
 
     'slides' => [
         'calendar' => [

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Welcome to TryPost! Your trial has started.',
     ],
 
-    'legal' => 'By continuing, you agree to our <a href="https://trypost.it/terms" target="_blank">Terms of Service</a> and <a href="https://trypost.it/privacy" target="_blank">Privacy Policy</a>.',
+    'legal' => 'By continuing, you agree to our <a href="https://madevisible.io/agb/" target="_blank">Terms of Service</a> and <a href="https://madevisible.io/privacy/" target="_blank">Privacy Policy</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/es/auth.php
+++ b/lang/es/auth.php
@@ -10,7 +10,7 @@ return [
         'welcome_trial' => '¡Bienvenido a TryPost! Tu prueba ha comenzado.',
     ],
 
-    'legal' => 'Al continuar, aceptas nuestros <a href="https://trypost.it/terms" target="_blank">Términos de Servicio</a> y <a href="https://trypost.it/privacy" target="_blank">Política de Privacidad</a>.',
+    'legal' => 'Al continuar, aceptas nuestros <a href="https://madevisible.io/agb/" target="_blank">Términos de Servicio</a> y <a href="https://madevisible.io/privacy/" target="_blank">Política de Privacidad</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/fr/auth.php
+++ b/lang/fr/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Bienvenue sur TryPost ! Votre essai a commencé.',
     ],
 
-    'legal' => 'En continuant, vous acceptez nos <a href="https://trypost.it/terms" target="_blank">Conditions d\'utilisation</a> et notre <a href="https://trypost.it/privacy" target="_blank">Politique de confidentialité</a>.',
+    'legal' => 'En continuant, vous acceptez nos <a href="https://madevisible.io/agb/" target="_blank">Conditions d\'utilisation</a> et notre <a href="https://madevisible.io/privacy/" target="_blank">Politique de confidentialité</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/it/auth.php
+++ b/lang/it/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Benvenuto su TryPost! La tua prova è iniziata.',
     ],
 
-    'legal' => 'Continuando, accetti i nostri <a href="https://trypost.it/terms" target="_blank">Termini di servizio</a> e la nostra <a href="https://trypost.it/privacy" target="_blank">Informativa sulla privacy</a>.',
+    'legal' => 'Continuando, accetti i nostri <a href="https://madevisible.io/agb/" target="_blank">Termini di servizio</a> e la nostra <a href="https://madevisible.io/privacy/" target="_blank">Informativa sulla privacy</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/ja/auth.php
+++ b/lang/ja/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'TryPost へようこそ！トライアルが開始されました。',
     ],
 
-    'legal' => '続行すると、<a href="https://trypost.it/terms" target="_blank">利用規約</a>および<a href="https://trypost.it/privacy" target="_blank">プライバシーポリシー</a>に同意したものとみなされます。',
+    'legal' => '続行すると、<a href="https://madevisible.io/agb/" target="_blank">利用規約</a>および<a href="https://madevisible.io/privacy/" target="_blank">プライバシーポリシー</a>に同意したものとみなされます。',
 
     'slides' => [
         'calendar' => [

--- a/lang/ko/auth.php
+++ b/lang/ko/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'TryPost에 오신 것을 환영합니다! 체험이 시작되었습니다.',
     ],
 
-    'legal' => '계속 진행하면 <a href="https://trypost.it/terms" target="_blank">서비스 약관</a> 및 <a href="https://trypost.it/privacy" target="_blank">개인정보 처리방침</a>에 동의하는 것입니다.',
+    'legal' => '계속 진행하면 <a href="https://madevisible.io/agb/" target="_blank">서비스 약관</a> 및 <a href="https://madevisible.io/privacy/" target="_blank">개인정보 처리방침</a>에 동의하는 것입니다.',
 
     'slides' => [
         'calendar' => [

--- a/lang/nl/auth.php
+++ b/lang/nl/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Welkom bij TryPost! Je proefperiode is gestart.',
     ],
 
-    'legal' => 'Door door te gaan ga je akkoord met onze <a href="https://trypost.it/terms" target="_blank">Servicevoorwaarden</a> en <a href="https://trypost.it/privacy" target="_blank">Privacybeleid</a>.',
+    'legal' => 'Door door te gaan ga je akkoord met onze <a href="https://madevisible.io/agb/" target="_blank">Servicevoorwaarden</a> en <a href="https://madevisible.io/privacy/" target="_blank">Privacybeleid</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/pl/auth.php
+++ b/lang/pl/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Witamy w TryPost! Twój okres próbny właśnie się rozpoczął.',
     ],
 
-    'legal' => 'Kontynuując, akceptujesz nasze <a href="https://trypost.it/terms" target="_blank">Warunki korzystania z usługi</a> oraz <a href="https://trypost.it/privacy" target="_blank">Politykę prywatności</a>.',
+    'legal' => 'Kontynuując, akceptujesz nasze <a href="https://madevisible.io/agb/" target="_blank">Warunki korzystania z usługi</a> oraz <a href="https://madevisible.io/privacy/" target="_blank">Politykę prywatności</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/pt-BR/auth.php
+++ b/lang/pt-BR/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Bem-vindo ao TryPost! Seu período de teste começou.',
     ],
 
-    'legal' => 'Ao continuar, você concorda com nossos <a href="https://trypost.it/terms" target="_blank">Termos de Serviço</a> e <a href="https://trypost.it/privacy" target="_blank">Política de Privacidade</a>.',
+    'legal' => 'Ao continuar, você concorda com nossos <a href="https://madevisible.io/agb/" target="_blank">Termos de Serviço</a> e <a href="https://madevisible.io/privacy/" target="_blank">Política de Privacidade</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/ru/auth.php
+++ b/lang/ru/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Добро пожаловать в TryPost! Ваш пробный период начался.',
     ],
 
-    'legal' => 'Продолжая, вы соглашаетесь с нашими <a href="https://trypost.it/terms" target="_blank">Условиями использования</a> и <a href="https://trypost.it/privacy" target="_blank">Политикой конфиденциальности</a>.',
+    'legal' => 'Продолжая, вы соглашаетесь с нашими <a href="https://madevisible.io/agb/" target="_blank">Условиями использования</a> и <a href="https://madevisible.io/privacy/" target="_blank">Политикой конфиденциальности</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/tr/auth.php
+++ b/lang/tr/auth.php
@@ -24,7 +24,7 @@ return [
         'welcome_trial' => 'TryPost\'a hoş geldiniz! Deneme süreniz başladı.',
     ],
 
-    'legal' => 'Devam ederek <a href="https://trypost.it/terms" target="_blank">Hizmet Şartları</a> ve <a href="https://trypost.it/privacy" target="_blank">Gizlilik Politikası</a>\'nı kabul etmiş olursunuz.',
+    'legal' => 'Devam ederek <a href="https://madevisible.io/agb/" target="_blank">Hizmet Şartları</a> ve <a href="https://madevisible.io/privacy/" target="_blank">Gizlilik Politikası</a>\'nı kabul etmiş olursunuz.',
 
     'slides' => [
         'calendar' => [

--- a/lang/uk/auth.php
+++ b/lang/uk/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => 'Ласкаво просимо до TryPost! Ваш пробний період розпочато.',
     ],
 
-    'legal' => 'Продовжуючи, ви погоджуєтеся з нашими <a href="https://trypost.it/terms" target="_blank">Умовами використання</a> та <a href="https://trypost.it/privacy" target="_blank">Політикою конфіденційності</a>.',
+    'legal' => 'Продовжуючи, ви погоджуєтеся з нашими <a href="https://madevisible.io/agb/" target="_blank">Умовами використання</a> та <a href="https://madevisible.io/privacy/" target="_blank">Політикою конфіденційності</a>.',
 
     'slides' => [
         'calendar' => [

--- a/lang/zh/auth.php
+++ b/lang/zh/auth.php
@@ -22,7 +22,7 @@ return [
         'welcome_trial' => '欢迎使用 TryPost！你的试用已开始。',
     ],
 
-    'legal' => '继续即表示你同意我们的<a href="https://trypost.it/terms" target="_blank">服务条款</a>和<a href="https://trypost.it/privacy" target="_blank">隐私政策</a>。',
+    'legal' => '继续即表示你同意我们的<a href="https://madevisible.io/agb/" target="_blank">服务条款</a>和<a href="https://madevisible.io/privacy/" target="_blank">隐私政策</a>。',
 
     'slides' => [
         'calendar' => [

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -16,65 +16,65 @@
 
 
 :root {
-  /* TryPost design system — warm cream + ink + signature violet.
-     Mirrors the marketing site (~/Herd/trypost-site) so the app and the
-     site share one identity. All structural borders are ink-black. */
-  --background: #faf8f5;
-  --foreground: #0a0a0a;
+  /* madevisible.io brand tokens (Mediterranean Light / Premium), see
+     digital-mind-agency/DESIGN.md. Replaces the upstream Gumroad-style
+     warm cream + violet identity for this concept branch. */
+  --background: #fbf7f1;
+  --foreground: #0a2540;
   --card: #ffffff;
-  --card-foreground: #0a0a0a;
+  --card-foreground: #0a2540;
   --popover: #ffffff;
-  --popover-foreground: #0a0a0a;
-  --primary: #7c3aed;
+  --popover-foreground: #0a2540;
+  --primary: #0c6e6d;
   --primary-foreground: #ffffff;
-  --secondary: #f4f4f0;
-  --secondary-foreground: #0a0a0a;
-  --muted: #f4f4f0;
-  --muted-foreground: #52525b;
-  --accent: #ede9fe;
-  --accent-foreground: #5b21b6;
-  --destructive: #e54b4f;
+  --secondary: #f4ece0;
+  --secondary-foreground: #0a2540;
+  --muted: #f4ece0;
+  --muted-foreground: #475c73;
+  --accent: #c99a5c;
+  --accent-foreground: #0a2540;
+  --destructive: #b8462f;
   --destructive-foreground: #ffffff;
-  --success: #16a34a;
-  --error: #e54b4f;
-  --warning: #d97706;
-  --info: #2563eb;
-  --border: #0a0a0a;
-  --input: #0a0a0a;
-  --ring: #7c3aed;
-  --chart-1: #7c3aed;
-  --chart-2: #8b5cf6;
-  --chart-3: #a78bfa;
-  --chart-4: #5b21b6;
-  --chart-5: #4c1d95;
+  --success: #0f8a88;
+  --error: #b8462f;
+  --warning: #c99a5c;
+  --info: #0c6e6d;
+  --border: #0a2540;
+  --input: #0a2540;
+  --ring: #0c6e6d;
+  --chart-1: #0c6e6d;
+  --chart-2: #0f8a88;
+  --chart-3: #a67c3f;
+  --chart-4: #084e4d;
+  --chart-5: #806026;
   --sidebar: #ffffff;
-  --sidebar-foreground: #0a0a0a;
-  --sidebar-primary: #7c3aed;
+  --sidebar-foreground: #0a2540;
+  --sidebar-primary: #0c6e6d;
   --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #ede9fe;
-  --sidebar-accent-foreground: #5b21b6;
-  --sidebar-border: #0a0a0a;
-  --sidebar-ring: #7c3aed;
-  --font-sans: Figtree, ui-sans-serif, system-ui, -apple-system,
+  --sidebar-accent: #c99a5c;
+  --sidebar-accent-foreground: #0a2540;
+  --sidebar-border: #0a2540;
+  --sidebar-ring: #0c6e6d;
+  --font-sans: Geist, ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
     'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
-  --font-serif: 'Instrument Serif', ui-serif, Georgia, Cambria,
-    'Times New Roman', Times, serif;
-  --font-display: 'Instrument Serif', ui-serif, Georgia, Cambria,
-    'Times New Roman', Times, serif;
+  --font-serif: Geist, ui-sans-serif, system-ui, -apple-system,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-display: Geist, ui-sans-serif, system-ui, -apple-system,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, 'Liberation Mono', 'Courier New', monospace;
-  --radius: 0.75rem;
-  /* Gumroad-style offset shadows: solid ink, no blur. */
-  --shadow-2xs: 1px 1px 0 0 #0a0a0a;
-  --shadow-xs: 2px 2px 0 0 #0a0a0a;
-  --shadow-sm: 3px 3px 0 0 #0a0a0a;
-  --shadow: 4px 4px 0 0 #0a0a0a;
-  --shadow-md: 5px 5px 0 0 #0a0a0a;
-  --shadow-lg: 6px 6px 0 0 #0a0a0a;
-  --shadow-xl: 8px 8px 0 0 #0a0a0a;
-  --shadow-2xl: 10px 10px 0 0 #0a0a0a;
+  --radius: 10px;
+  /* Soft tinted shadows instead of the upstream hard-ink offset shadows. */
+  --shadow-2xs: 0px 1px 2px 0 rgba(10, 37, 64, 0.05);
+  --shadow-xs: 0px 1px 3px 0 rgba(10, 37, 64, 0.06);
+  --shadow-sm: 0px 2px 4px 0 rgba(10, 37, 64, 0.07);
+  --shadow: 0px 4px 8px 0 rgba(10, 37, 64, 0.08);
+  --shadow-md: 0px 6px 12px 0 rgba(10, 37, 64, 0.08);
+  --shadow-lg: 0px 10px 20px 0 rgba(10, 37, 64, 0.09);
+  --shadow-xl: 0px 16px 32px 0 rgba(10, 37, 64, 0.1);
+  --shadow-2xl: 0px 24px 48px 0 rgba(10, 37, 64, 0.12);
   --tracking-normal: 0em;
   --spacing: 0.25rem;
 }

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -4,14 +4,12 @@ import {
     IconAffiliate,
     IconAlertTriangle,
     IconBolt,
-    IconBrandDiscord,
     IconCalendar,
     IconChartBar,
     IconChevronRight,
     IconClock,
     IconFileCheck,
     IconFileText,
-    IconGift,
     IconHash,
     IconLifebuoy,
     IconPencil,
@@ -173,16 +171,6 @@ const workspaceNavItems = computed<NavItem[]>(() => [
 ]);
 
 const bottomNavItems = computed(() => [
-    {
-        title: trans('sidebar.support.referral'),
-        href: 'https://affiliates.trypost.it/',
-        icon: IconGift,
-    },
-    {
-        title: trans('sidebar.support.discord'),
-        href: 'https://trypost.it/discord',
-        icon: IconBrandDiscord,
-    },
     {
         title: trans('sidebar.support.docs'),
         href: 'https://docs.trypost.it',

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -183,6 +183,12 @@ const pageErrors = usePageErrors();
                     }}</TextLink>
                 </div>
             </Form>
+
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div
+                class="text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 [&_a]:hover:text-primary"
+                v-html="$t('auth.legal')"
+            />
         </div>
     </AuthBase>
 </template>

--- a/resources/js/pages/auth/Register.vue
+++ b/resources/js/pages/auth/Register.vue
@@ -29,7 +29,6 @@ const showPassword = ref(false);
 const showEmailForm = ref(false);
 
 const page = usePage();
-const isSelfHosted = computed(() => Boolean(page.props.selfHosted));
 const hasSocial = computed(
     () =>
         Boolean(page.props.googleAuthEnabled) ||
@@ -178,7 +177,6 @@ const emailFormVisible = computed(() => !hasSocial.value || showEmailForm.value)
 
             <!-- eslint-disable-next-line vue/no-v-html -->
             <div
-                v-if="!isSelfHosted"
                 class="text-center text-xs text-muted-foreground [&_a]:underline [&_a]:underline-offset-4 [&_a]:hover:text-primary"
                 v-html="$t('auth.legal')"
             />

--- a/tests/Feature/Mcp/WorkspaceToolTest.php
+++ b/tests/Feature/Mcp/WorkspaceToolTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\UserWorkspace\Role;
 use App\Mcp\Servers\TryPostServer;
 use App\Mcp\Tools\Workspace\GetWorkspaceTool;
+use App\Mcp\Tools\Workspace\UpdateWorkspaceTool;
 use App\Models\User;
 use App\Models\Workspace;
 use Illuminate\Testing\Fluent\AssertableJson;
@@ -30,4 +31,90 @@ test('get workspace returns sanitized WorkspaceResource shape', function () {
                 ->missing('brand_color')
                 ->missing('content_language');
         });
+});
+
+test('update workspace sets a valid field and leaves others untouched', function () {
+    $this->workspace->members()->updateExistingPivot($this->user->id, ['role' => Role::Admin->value]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(UpdateWorkspaceTool::class, [
+            'brand_description' => 'A friendly, no hype coffee brand.',
+        ]);
+
+    $response->assertOk()
+        ->assertStructuredContent(function (AssertableJson $json) {
+            $json->where('id', $this->workspace->id)
+                ->where('name', $this->workspace->name)
+                ->hasAll(['created_at', 'updated_at']);
+        });
+
+    $this->workspace->refresh();
+
+    expect($this->workspace->brand_description)->toBe('A friendly, no hype coffee brand.')
+        ->and($this->workspace->content_language)->toBe('en');
+});
+
+test('update workspace rejects an invalid brand color', function () {
+    $this->workspace->members()->updateExistingPivot($this->user->id, ['role' => Role::Admin->value]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(UpdateWorkspaceTool::class, [
+            'brand_color' => 'not-a-hex-color',
+        ]);
+
+    $response->assertHasErrors();
+
+    expect($this->workspace->fresh()->brand_color)->toBeNull();
+});
+
+test('update workspace only touches the caller current workspace, other workspaces are untouched', function () {
+    $this->workspace->members()->updateExistingPivot($this->user->id, ['role' => Role::Admin->value]);
+
+    $otherWorkspace = Workspace::factory()->create(['name' => 'Untouched Workspace']);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(UpdateWorkspaceTool::class, [
+            'name' => 'Hijacked',
+        ]);
+
+    $response->assertOk();
+
+    expect($otherWorkspace->fresh()->name)->toBe('Untouched Workspace')
+        ->and($this->workspace->fresh()->name)->toBe('Hijacked');
+});
+
+test('update workspace denies a member without admin or owner role', function () {
+    // $this->user auto-owns its own freshly-created account (see UserFactory::configure()),
+    // so a real "non-owner member" needs a second user sharing that SAME account, the way
+    // McpRoleAuthorizationTest builds its viewer/member fixtures.
+    $member = User::factory()->create(['account_id' => $this->user->account_id]);
+    $this->workspace->members()->attach($member->id, ['role' => Role::Member->value]);
+    $member->update(['current_workspace_id' => $this->workspace->id]);
+
+    $response = TryPostServer::actingAs($member)
+        ->tool(UpdateWorkspaceTool::class, [
+            'name' => 'Should Not Apply',
+        ]);
+
+    $response->assertHasErrors(['Not authorized to update this workspace.']);
+
+    expect($this->workspace->fresh()->name)->not->toBe('Should Not Apply');
+});
+
+test('update workspace coerces brand_voice_traits to a coherent selection', function () {
+    $this->workspace->members()->updateExistingPivot($this->user->id, ['role' => Role::Admin->value]);
+
+    $response = TryPostServer::actingAs($this->user)
+        ->tool(UpdateWorkspaceTool::class, [
+            'brand_voice_traits' => ['formal', 'casual', 'direct'],
+        ]);
+
+    $response->assertOk();
+
+    $traits = $this->workspace->fresh()->brand_voice_traits;
+
+    expect($traits)->toContain('direct')
+        ->and($traits)->toContain('formal')
+        ->and($traits)->not->toContain('casual')
+        ->and($traits)->toHaveCount(2);
 });


### PR DESCRIPTION
## Summary
- TikTok App Review rejected `madevisible.io Social` on 04.09.2026, third point: "Valid Privacy Policy and Terms of Service links must be clearly visible on the website URL without needing to open a menu or log in, and both links must be active." Live-verified with Playwright (fresh, cookie-cleared session, confirmed "Log in - TryPost" i.e. real logged-out state): the login page had zero legal links, only "Forgot password?".
- Root cause: the only legal-footer block (`auth.legal` i18n key) was rendered only in `Register.vue`, gated behind `v-if="!isSelfHosted"`. This deployment runs `trypost.self_hosted=true`, so the footer was unconditionally hidden. `Login.vue` never had the block at all.
- Fix: dropped the self-hosted guard on `Register.vue` (always shows now), added the same footer block to `Login.vue`, and repointed the hardcoded `trypost.it/terms`/`trypost.it/privacy` URLs in all 16 locale files to `https://madevisible.io/agb/` and `https://madevisible.io/privacy/` (both now name "madevisible.io Social" by name, see Cryptoom/digital-mind-agency#396).
- Documented as Patch 4 in `PATCHES.md` with merge-safety marker strings, following the existing pattern from Patches 1-3.

## Test plan
- [x] `php -l` on all 16 modified `lang/*/auth.php` files
- [x] Tag-balance check on `Login.vue`/`Register.vue` (div open/close counts match)
- [x] `check-dashes.sh` clean (2 pre-existing em-dashes in untouched upstream copy elsewhere in the same files, confirmed via diff that they are NOT part of this change)
- [ ] No local build environment available (no `node_modules`), verification happens via the real `docker compose up -d --build` rebuild on web02 after merge
- [ ] Live-verify `social.madevisible.io/login` and `/register` show the footer with working links to `madevisible.io/agb/` and `/privacy/`, logged out, no menu needed
- [ ] Resubmit the TikTok app for review once this + Cryptoom/digital-mind-agency#396 are both live

🤖 Generated with [Claude Code](https://claude.com/claude-code)