### PR TITLE
Show disconnect alongside reconnect on lost social connections

### DIFF
--- a/resources/js/components/accounts/NetworkConnectGrid.vue
+++ b/resources/js/components/accounts/NetworkConnectGrid.vue
@@ -234,19 +234,34 @@ const cards = computed<ConnectCard[]>(() => {
                     </p>
                 </div>
 
-                <Button
+                <div
                     v-if="card.state === 'reconnect' && card.account"
-                    size="sm"
-                    class="mt-auto w-full"
-                    @click="startConnect(card.account.platform, card.account.id)"
+                    class="mt-auto flex w-full flex-col gap-2"
                 >
-                    {{ $t('accounts.reconnect') }}
-                </Button>
+                    <Button
+                        size="sm"
+                        class="w-full"
+                        :data-testid="`reconnect-${card.account.id}`"
+                        @click="startConnect(card.account.platform, card.account.id)"
+                    >
+                        {{ $t('accounts.reconnect') }}
+                    </Button>
+                    <Button
+                        variant="destructive"
+                        size="sm"
+                        class="w-full"
+                        :data-testid="`disconnect-${card.account.id}`"
+                        @click="disconnectAccount(card.account)"
+                    >
+                        {{ $t('accounts.disconnect') }}
+                    </Button>
+                </div>
                 <Button
                     v-else-if="card.state === 'connected' && card.account"
                     variant="destructive"
                     size="sm"
                     class="mt-auto w-full"
+                    :data-testid="`disconnect-${card.account.id}`"
                     @click="disconnectAccount(card.account)"
                 >
                     {{ $t('accounts.disconnect') }}

--- a/tests/Browser/NetworkConnectGridTest.php
+++ b/tests/Browser/NetworkConnectGridTest.php
@@ -71,3 +71,22 @@ test('a taken network offers another card when multiples are allowed', function 
         ->assertVisible('@connect-x')
         ->assertNoJavaScriptErrors();
 });
+
+test('a lost connection offers both reconnect and disconnect', function () {
+    $user = gridOwnerWithLinkedIn();
+
+    $account = SocialAccount::factory()->x()->tokenExpired()->create([
+        'workspace_id' => $user->current_workspace_id,
+        'platform_user_id' => 'x-expired',
+    ]);
+
+    $this->actingAs($user);
+
+    $page = visit(route('app.accounts'));
+
+    waitForGridTestId($page, "disconnect-{$account->id}");
+
+    $page->assertVisible("@reconnect-{$account->id}")
+        ->assertVisible("@disconnect-{$account->id}")
+        ->assertNoJavaScriptErrors();
+});


### PR DESCRIPTION
## Summary

On `/accounts`, when a social account's connection is lost (`disconnected` or `token_expired`), the card only offered **Reconnect**. A user who wanted to drop that account and connect a different one couldn't do it from the UI.

The lost-connection card now shows **Reconnect** and **Disconnect** stacked. Disconnect reuses the existing confirmation modal and `app.accounts.disconnect` route, which already accepts accounts in any status, so this is a frontend-only change.

## Changes

- `resources/js/components/accounts/NetworkConnectGrid.vue`: render both buttons in the `reconnect` state; add `data-testid` on reconnect/disconnect buttons keyed by account id.
- `tests/Browser/NetworkConnectGridTest.php`: new browser test seeding a `tokenExpired()` X account and asserting both buttons are visible.

## Test plan

- [x] `php artisan test tests/Browser/NetworkConnectGridTest.php --compact` (3 passed, against `npm run build` output)
- [x] `npx eslint resources/js/components/accounts/NetworkConnectGrid.vue`
- [x] `vendor/bin/pint --dirty`