### PR TITLE
Allow native MCP clients to register OAuth redirect schemes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,10 +28,6 @@ META_PAGE_WALK_SECONDS=20
 # PASSPORT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 # PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
 
-# Extra native MCP OAuth redirect schemes (RFC 8252), comma-separated.
-# Appended to the built-in desktop-agent allowlist (cursor, vscode, claude, …).
-# MCP_CUSTOM_SCHEMES=
-
 TELESCOPE_ENABLED=false
 
 APP_LOCALE=en

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ META_PAGE_WALK_SECONDS=20
 # PASSPORT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 # PASSPORT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----"
 
+# Extra native MCP OAuth redirect schemes (RFC 8252), comma-separated.
+# Appended to the built-in desktop-agent allowlist (cursor, vscode, claude, …).
+# MCP_CUSTOM_SCHEMES=
+
 TELESCOPE_ENABLED=false
 
 APP_LOCALE=en

--- a/config/mcp.php
+++ b/config/mcp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
 
     /*
@@ -17,8 +19,6 @@ return [
 
     'redirect_domains' => [
         '*',
-        // 'https://example.com',
-        // 'http://localhost',
     ],
 
     /*

--- a/config/mcp.php
+++ b/config/mcp.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 return [
 
     /*
@@ -19,6 +17,8 @@ return [
 
     'redirect_domains' => [
         '*',
+        // 'https://example.com',
+        // 'http://localhost',
     ],
 
     /*
@@ -26,50 +26,40 @@ return [
     | Allowed Custom Schemes
     |--------------------------------------------------------------------------
     |
-    | Native desktop OAuth clients use private-use URI schemes (RFC 8252)
-    | for redirect callbacks — e.g. Cursor registers
-    | cursor://anysphere.cursor-mcp/oauth/callback. HTTP(S) and loopback
-    | redirects (Claude.ai, ChatGPT, Hermes, OpenCode, Codex CLI, …) are
-    | already accepted via redirect_domains. This list is the scheme
-    | allowlist for the native-app case.
+    | Native desktop OAuth clients like Cursor and VS Code use private-use URI
+    | schemes (RFC 8252) for redirect callbacks instead of standard schemes
+    | like HTTPS. Here, you may list which custom schemes you will allow.
     |
     */
 
     'custom_schemes' => [
-        // Desktop IDEs / agent hosts
         'antigravity',
-        'cursor',
-        'jetbrains',
-        'kiro',
-        'trae',
-        'vscode',
-        'vscode-insiders',
-        'windsurf',
-        'zed',
-
-        // Anthropic
+        'chatgpt',
         'claude',
         'claude-cli',
         'claude-code',
         'claude-desktop',
         'claudeai',
-
-        // OpenAI / xAI
-        'chatgpt',
         'codex',
-        'grok',
-        'xai',
-
-        // Agent CLIs and hosts
         'codium',
         'continue',
+        'cursor',
         'devin',
         'goose',
+        'grok',
         'hermes',
+        'jetbrains',
+        'kiro',
         'lmstudio',
         'opencode',
         'raycast',
+        'trae',
+        'vscode',
+        'vscode-insiders',
         'warp',
+        'windsurf',
+        'xai',
+        'zed',
     ],
 
     /*
@@ -84,5 +74,21 @@ return [
     */
 
     'authorization_server' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tool Search
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the limits enforced during tool search. The maximum
+    | number of tool calls limits how many tools each search request can run
+    | while the maximum output bytes value caps the size of every result.
+    |
+    */
+
+    'tool_search' => [
+        'max_tool_calls' => 10,
+        'max_output_bytes' => 65_536,
+    ],
 
 ];

--- a/config/mcp.php
+++ b/config/mcp.php
@@ -2,11 +2,6 @@
 
 declare(strict_types=1);
 
-$extraCustomSchemes = array_values(array_filter(array_map(
-    'trim',
-    explode(',', (string) env('MCP_CUSTOM_SCHEMES', '')),
-)));
-
 return [
 
     /*
@@ -38,12 +33,9 @@ return [
     | already accepted via redirect_domains. This list is the scheme
     | allowlist for the native-app case.
     |
-    | MCP_CUSTOM_SCHEMES appends extra schemes (comma-separated) without
-    | replacing the defaults.
-    |
     */
 
-    'custom_schemes' => array_values(array_unique([
+    'custom_schemes' => [
         // Desktop IDEs / agent hosts
         'antigravity',
         'cursor',
@@ -78,9 +70,7 @@ return [
         'opencode',
         'raycast',
         'warp',
-
-        ...$extraCustomSchemes,
-    ])),
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/config/mcp.php
+++ b/config/mcp.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+$extraCustomSchemes = array_values(array_filter(array_map(
+    'trim',
+    explode(',', (string) env('MCP_CUSTOM_SCHEMES', '')),
+)));
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redirect Domains
+    |--------------------------------------------------------------------------
+    |
+    | These domains are the domains that OAuth clients are permitted to use
+    | for redirect URIs. Each domain should be specified with its scheme
+    | and host. Domains not in this list will raise validation errors.
+    |
+    | An "*" may be used to allow all domains.
+    |
+    */
+
+    'redirect_domains' => [
+        '*',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed Custom Schemes
+    |--------------------------------------------------------------------------
+    |
+    | Native desktop OAuth clients use private-use URI schemes (RFC 8252)
+    | for redirect callbacks — e.g. Cursor registers
+    | cursor://anysphere.cursor-mcp/oauth/callback. HTTP(S) and loopback
+    | redirects (Claude.ai, ChatGPT, Hermes, OpenCode, Codex CLI, …) are
+    | already accepted via redirect_domains. This list is the scheme
+    | allowlist for the native-app case.
+    |
+    | MCP_CUSTOM_SCHEMES appends extra schemes (comma-separated) without
+    | replacing the defaults.
+    |
+    */
+
+    'custom_schemes' => array_values(array_unique([
+        // Desktop IDEs / agent hosts
+        'antigravity',
+        'cursor',
+        'jetbrains',
+        'kiro',
+        'trae',
+        'vscode',
+        'vscode-insiders',
+        'windsurf',
+        'zed',
+
+        // Anthropic
+        'claude',
+        'claude-cli',
+        'claude-code',
+        'claude-desktop',
+        'claudeai',
+
+        // OpenAI / xAI
+        'chatgpt',
+        'codex',
+        'grok',
+        'xai',
+
+        // Agent CLIs and hosts
+        'codium',
+        'continue',
+        'devin',
+        'goose',
+        'hermes',
+        'lmstudio',
+        'opencode',
+        'raycast',
+        'warp',
+
+        ...$extraCustomSchemes,
+    ])),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authorization Server
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the OAuth authorization server issuer identifier
+    | per RFC 8414. This value appears in your protected resource and auth
+    | server metadata endpoints. When null, this defaults to `url('/')`.
+    |
+    */
+
+    'authorization_server' => null,
+
+];

--- a/tests/Feature/Mcp/OAuthRegistrationTest.php
+++ b/tests/Feature/Mcp/OAuthRegistrationTest.php
@@ -10,6 +10,42 @@ use App\Models\Workspace;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
+/**
+ * @return list<string>
+ */
+function mcpNativeAgentSchemes(): array
+{
+    return [
+        'antigravity',
+        'chatgpt',
+        'claude',
+        'claude-cli',
+        'claude-code',
+        'claude-desktop',
+        'claudeai',
+        'codex',
+        'codium',
+        'continue',
+        'cursor',
+        'devin',
+        'goose',
+        'grok',
+        'hermes',
+        'jetbrains',
+        'kiro',
+        'lmstudio',
+        'opencode',
+        'raycast',
+        'trae',
+        'vscode',
+        'vscode-insiders',
+        'warp',
+        'windsurf',
+        'xai',
+        'zed',
+    ];
+}
+
 test('dynamic oauth client registration is rate limited', function () {
     $payload = [
         'client_name' => 'MCP Client',
@@ -26,7 +62,21 @@ test('dynamic oauth client registration is rate limited', function () {
     $this->postJson('/oauth/register', $payload)->assertTooManyRequests();
 });
 
-test('dynamic oauth registration accepts native agent custom callback schemes', function (string $redirectUri) {
+test('mcp custom schemes config lists every supported native agent', function () {
+    expect(config('mcp.custom_schemes'))->toEqual(mcpNativeAgentSchemes());
+});
+
+test('dynamic oauth registration accepts every configured custom callback scheme', function (string $scheme) {
+    $this->postJson('/oauth/register', [
+        'client_name' => 'Native MCP Client',
+        'redirect_uris' => ["{$scheme}://oauth/callback"],
+        'grant_types' => ['authorization_code'],
+        'response_types' => ['code'],
+        'token_endpoint_auth_method' => 'none',
+    ])->assertCreated();
+})->with(mcpNativeAgentSchemes());
+
+test('dynamic oauth registration accepts documented native and loopback callbacks', function (string $redirectUri) {
     $this->postJson('/oauth/register', [
         'client_name' => 'Native MCP Client',
         'redirect_uris' => [$redirectUri],
@@ -35,21 +85,16 @@ test('dynamic oauth registration accepts native agent custom callback schemes', 
         'token_endpoint_auth_method' => 'none',
     ])->assertCreated();
 })->with([
-    'cursor documented' => 'cursor://anysphere.cursor-mcp/oauth/callback',
-    'cursor' => 'cursor://oauth/callback',
-    'vscode' => 'vscode://oauth/callback',
-    'vscode-insiders' => 'vscode-insiders://oauth/callback',
-    'claude' => 'claude://oauth/callback',
-    'claude-desktop' => 'claude-desktop://oauth/callback',
-    'claude-code' => 'claude-code://oauth/callback',
-    'windsurf' => 'windsurf://oauth/callback',
-    'zed' => 'zed://oauth/callback',
-    'raycast' => 'raycast://oauth',
-    'grok' => 'grok://oauth/callback',
-    'hermes' => 'hermes://oauth/callback',
-    'opencode' => 'opencode://oauth/callback',
-    'continue' => 'continue://oauth/callback',
-    'codex' => 'codex://oauth/callback',
+    'cursor anysphere' => 'cursor://anysphere.cursor-mcp/oauth/callback',
+    'cursor mcp host' => 'cursor://cursor.mcp/oauth/callback',
+    'raycast oauth' => 'raycast://oauth',
+    'cursor loopback' => 'http://localhost:8787/callback',
+    'opencode loopback' => 'http://127.0.0.1:19876/mcp/oauth/callback',
+    'hermes loopback' => 'http://127.0.0.1:8765/callback',
+    'claude https' => 'https://claude.ai/api/mcp/auth_callback',
+    'chatgpt https' => 'https://chatgpt.com/aip/mcp/oauth/callback',
+    'cursor web' => 'https://www.cursor.com/agents/mcp/oauth/callback',
+    'antigravity https' => 'https://antigravity.google/oauth-callback',
 ]);
 
 test('dynamic oauth registration rejects unknown and unsafe callback schemes', function (string $redirectUri) {

--- a/tests/Feature/Mcp/OAuthRegistrationTest.php
+++ b/tests/Feature/Mcp/OAuthRegistrationTest.php
@@ -26,18 +26,63 @@ test('dynamic oauth client registration is rate limited', function () {
     $this->postJson('/oauth/register', $payload)->assertTooManyRequests();
 });
 
-test('dynamic oauth registration rejects custom callback schemes', function (string $redirectUri) {
+test('dynamic oauth registration accepts native agent custom callback schemes', function (string $redirectUri) {
     $this->postJson('/oauth/register', [
         'client_name' => 'Native MCP Client',
         'redirect_uris' => [$redirectUri],
         'grant_types' => ['authorization_code'],
         'response_types' => ['code'],
         'token_endpoint_auth_method' => 'none',
-    ])->assertBadRequest();
+    ])->assertCreated();
 })->with([
+    'cursor documented' => 'cursor://anysphere.cursor-mcp/oauth/callback',
     'cursor' => 'cursor://oauth/callback',
     'vscode' => 'vscode://oauth/callback',
+    'vscode-insiders' => 'vscode-insiders://oauth/callback',
+    'claude' => 'claude://oauth/callback',
+    'claude-desktop' => 'claude-desktop://oauth/callback',
+    'claude-code' => 'claude-code://oauth/callback',
+    'windsurf' => 'windsurf://oauth/callback',
+    'zed' => 'zed://oauth/callback',
+    'raycast' => 'raycast://oauth',
+    'grok' => 'grok://oauth/callback',
+    'hermes' => 'hermes://oauth/callback',
+    'opencode' => 'opencode://oauth/callback',
+    'continue' => 'continue://oauth/callback',
+    'codex' => 'codex://oauth/callback',
 ]);
+
+test('dynamic oauth registration rejects unknown and unsafe callback schemes', function (string $redirectUri) {
+    $this->postJson('/oauth/register', [
+        'client_name' => 'Native MCP Client',
+        'redirect_uris' => [$redirectUri],
+        'grant_types' => ['authorization_code'],
+        'response_types' => ['code'],
+        'token_endpoint_auth_method' => 'none',
+    ])
+        ->assertBadRequest()
+        ->assertJson([
+            'error' => 'invalid_redirect_uri',
+        ]);
+})->with([
+    'javascript' => 'javascript:alert(1)',
+    'data' => 'data:text/html,hi',
+    'file' => 'file:///etc/passwd',
+    'unknown' => 'notanagent://oauth/callback',
+    'cursor missing host' => 'cursor:/callback',
+]);
+
+test('dynamic oauth registration accepts extra custom schemes from config', function () {
+    config()->set('mcp.custom_schemes', [...config('mcp.custom_schemes'), 'myagent']);
+
+    $this->postJson('/oauth/register', [
+        'client_name' => 'Custom Agent',
+        'redirect_uris' => ['myagent://oauth/callback'],
+        'grant_types' => ['authorization_code'],
+        'response_types' => ['code'],
+        'token_endpoint_auth_method' => 'none',
+    ])->assertCreated();
+});
 
 test('mcp oauth consent page is available for workspace viewers', function () {
     $account = Account::factory()->create();


### PR DESCRIPTION
## Summary
- Desktop agents (Cursor, VS Code, Claude Desktop, Windsurf, …) register RFC 8252 callbacks like `cursor://anysphere.cursor-mcp/oauth/callback`. Dynamic client registration rejected those because `mcp.custom_schemes` was empty, so OAuth never started (`redirect_uris.0 is not a valid URL`).
- Publish `config/mcp.php` with an allowlist of known native-agent schemes. HTTPS/loopback clients (ChatGPT, Hermes, OpenCode, Codex CLI) already passed via `redirect_domains: ['*']`.
- Still reject `javascript:`, `data:`, `file:`, unknown schemes, and custom URIs without a host.

## Test plan
- [ ] Connect Cursor to production MCP after deploy — consent should open instead of `connect_failure`
- [ ] Confirm VS Code / Claude Desktop DCR still completes
- [ ] Confirm a loopback client (Hermes / OpenCode) still registers with `http://127.0.0.1:…/callback`
- [ ] Confirm `javascript:` / unknown schemes still return 400 `invalid_redirect_uri`