### PR TITLE
Clear the vue-tsc baseline

### DIFF
--- a/resources/js/components/assets/GalleryBrowser.vue
+++ b/resources/js/components/assets/GalleryBrowser.vue
@@ -19,6 +19,7 @@ import { destroy as assetsDestroy, search as assetsSearch, storeChunked as asset
 import { search as giphySearch, trending as giphyTrending } from '@/routes/app/assets/giphy';
 import { search as unsplashSearch, trending as unsplashTrending } from '@/routes/app/assets/unsplash';
 import { store as storePost } from '@/routes/app/posts';
+import type { SourceMetaValue } from '@/types/media';
 import { uploadChunked } from '@/utils/chunkedUpload';
 
 interface AssetMedia {
@@ -74,7 +75,7 @@ interface PickedMedia {
     size?: number;
     meta?: { width?: number; height?: number; duration?: number };
     source?: 'ai' | 'unsplash' | 'giphy';
-    source_meta?: Record<string, unknown>;
+    source_meta?: Record<string, SourceMetaValue>;
 }
 
 const props = defineProps<{

--- a/resources/js/components/posts/PostPlatformMetrics.vue
+++ b/resources/js/components/posts/PostPlatformMetrics.vue
@@ -110,7 +110,7 @@ onMounted(async () => {
                 <Tooltip>
                     <TooltipTrigger as-child>
                         <span class="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                            <IconUsers class="size-4" :stroke="1.75" />
+                            <IconUsers class="size-4" stroke-width="1.75" />
                             <span class="font-semibold tabular-nums text-foreground">{{
                                 formatNumberCompact(subscribers.value)
                             }}</span>
@@ -126,7 +126,7 @@ onMounted(async () => {
                 <Tooltip>
                     <TooltipTrigger as-child>
                         <span class="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                            <IconMessageCircle class="size-4" :stroke="1.75" />
+                            <IconMessageCircle class="size-4" stroke-width="1.75" />
                             <span class="font-semibold tabular-nums text-foreground">{{
                                 formatNumberCompact(comments.value)
                             }}</span>

--- a/resources/js/composables/useWebhookLogs.ts
+++ b/resources/js/composables/useWebhookLogs.ts
@@ -82,7 +82,7 @@ export const useWebhookLogs = (
             selectedLog.value = next;
         }
 
-        router.reload({ only: ['logs'], preserveScroll: true });
+        router.reload({ only: ['logs'] });
     };
 
     useWebhookEcho(toValue(webhookId), '.webhook.log.updated', applyLogUpdate);

--- a/resources/js/pages/welcome/Connect.vue
+++ b/resources/js/pages/welcome/Connect.vue
@@ -8,6 +8,7 @@ import NetworkConnectGrid, {
 } from '@/components/accounts/NetworkConnectGrid.vue';
 import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
+import { usePageErrors } from '@/composables/usePageErrors';
 import WelcomeLayout from '@/layouts/WelcomeLayout.vue';
 import { store } from '@/routes/app/welcome/connect';
 import { SocialAccountStatus } from '@/types/social-account-status';
@@ -18,6 +19,8 @@ const props = defineProps<{
 }>();
 
 const form = useForm({});
+
+const errors = usePageErrors();
 
 const hasConnectedAccount = computed((): boolean =>
     props.accounts.some(
@@ -53,7 +56,8 @@ const submit = (): void => {
 
         <div class="mx-auto flex w-full max-w-sm flex-col items-center gap-3">
             <InputError
-                :message="form.errors.connect"
+                data-testid="welcome-connect-error"
+                :message="errors.connect"
             />
             <Button as-child size="lg" class="w-full rounded-full">
                 <button

--- a/resources/js/types/media.ts
+++ b/resources/js/types/media.ts
@@ -2,6 +2,8 @@ import type { MediaType } from '@/lib/mediaType';
 
 export type MediaSource = 'ai' | 'unsplash' | 'giphy';
 
+export type SourceMetaValue = string | number | boolean | null | SourceMetaValue[];
+
 export interface MediaItem {
     id: string;
     url: string;
@@ -11,7 +13,7 @@ export interface MediaItem {
     original_filename?: string;
     size?: number;
     source?: MediaSource;
-    source_meta?: Record<string, unknown>;
+    source_meta?: Record<string, SourceMetaValue>;
     meta?: {
         width?: number;
         height?: number;

--- a/tests/Browser/WelcomeConnectTest.php
+++ b/tests/Browser/WelcomeConnectTest.php
@@ -118,3 +118,30 @@ test('connect step redirects to persona when prior steps are missing', function 
     $page->assertRoute('app.welcome.persona')
         ->assertNoJavaScriptErrors();
 });
+
+test('connect step shows the backend error when the account disappears before submitting', function () {
+    config(['trypost.self_hosted' => false]);
+
+    $user = welcomeOwnerOnConnectStep();
+    $account = SocialAccount::factory()->linkedin()->create([
+        'workspace_id' => $user->current_workspace_id,
+    ]);
+
+    $this->actingAs($user->fresh());
+
+    $page = visit(route('app.welcome.connect'));
+
+    waitForWelcomeTestId($page, 'welcome-start-checkout');
+
+    $page->assertEnabled('@welcome-start-checkout');
+
+    $account->delete();
+
+    $page->click('@welcome-start-checkout');
+
+    waitForWelcomeTestId($page, 'welcome-connect-error');
+
+    $page->assertVisible('@welcome-connect-error')
+        ->assertSee(trans('welcome.connect.required'))
+        ->assertNoJavaScriptErrors();
+});


### PR DESCRIPTION
`npx vue-tsc --noEmit -p tsconfig.json` reported six errors on main; it reports none now. None of them were in the repurpose module, so #335 left them where they were.

### The mechanical four

- **`PostPlatformMetrics.vue:113,129`** — `:stroke="1.75"` binds a number and `@tabler/icons-vue` types `stroke` as a string. Every other icon in the app passes `stroke-width` as a plain attribute; these two were the only ones using `:stroke`, so they now match the rest.
- **`useWebhookLogs.ts:85`** — `router.reload({ only: ['logs'], preserveScroll: true })`. Inertia declares `ReloadOptions = Omit<VisitOptions, 'preserveScroll' | 'preserveState'>` because a reload always preserves both. The option was inert; dropping it changes nothing at runtime.
- **`welcome/Connect.vue:56`** — `form.errors.connect` on a `useForm({})`. That error is added by `StoreWelcomeConnectRequest::withValidator`, so it never was a form field. It now comes from `usePageErrors()`, which is how the platform settings panels already read errors with no matching field.

### The two that needed a decision

**`posts/Edit.vue:287,328`** — the `router.put` payload carries `media`, and `MediaItem.source_meta` was `Record<string, unknown>`, which cannot satisfy `FormDataConvertible`.

A cast would have silenced it without fixing anything. But `FormDataConvertible` accepts records and arrays recursively — the only thing it rejects is `unknown`. Checking what `source_meta` actually carries (`TemplateImageGenerator.php:143`, `RegeneratePostMediaImage.php`, and the Unsplash/Giphy pickers in `GalleryBrowser.vue`): strings, numbers, and lists of strings under `keywords`. So the type says that:

```ts
export type SourceMetaValue = string | number | boolean | null | SourceMetaValue[];
```

`GalleryBrowser.vue` had its own copy of the field declared as `Record<string, unknown>`; it imports the shared type now instead.

### Test

Moving where `Connect.vue` reads its error had no coverage — `WelcomeControllerTest` asserts `assertSessionHasErrors('connect')` three times, but nothing asserted the page renders it. The continue button stays disabled until an account connects, so the error only reaches the screen when the account disappears between page load and submit; the new browser test does exactly that. Confirmed it catches a break: replacing the message with `undefined` fails it.

### Verification

| | |
|---|---|
| `vue-tsc` | 6 → **0** |
| PostgreSQL | 4390 passing, 1 skipped |
| Browser | 43 passing (was 42) |
| `pint --test`, `eslint` | clean |

Closes #337