### PR TITLE
Make the social connect tests assert where the redirect actually goes

### DIFF
--- a/tests/Feature/Social/DiscordControllerTest.php
+++ b/tests/Feature/Social/DiscordControllerTest.php
@@ -19,6 +19,16 @@ beforeEach(function () {
     $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
 });
 
+test('discord authorize url asks for the bot scope and leaves the server picker open', function () {
+    $response = $this->actingAs($this->user)->get(route('app.social.discord.connect'));
+
+    expect(urldecode((string) $response->headers->get('Location')))
+        ->toStartWith('https://discord.com/api/oauth2/authorize')
+        ->toContain('scope=bot identify guilds')
+        ->toContain('permissions=248832')
+        ->not->toContain('disable_guild_select');
+});
+
 test('discord connect redirects to the oauth provider', function () {
     $driverMock = Mockery::mock();
     $driverMock->shouldReceive('scopes')->andReturnSelf();

--- a/tests/Feature/Social/DiscordControllerTest.php
+++ b/tests/Feature/Social/DiscordControllerTest.php
@@ -30,9 +30,8 @@ test('discord connect redirects to the oauth provider', function () {
     Socialite::shouldReceive('driver')->with('discord')->andReturn($driverMock);
 
     $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.discord.connect'))
-        ->assertStatus(409); // Inertia::location
+        ->assertRedirect('https://discord.com/api/oauth2/authorize?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -37,10 +37,9 @@ test('facebook connect redirects to oauth provider', function () {
         ->andReturn($driverMock);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.facebook.connect'));
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    $response->assertRedirect('https://www.facebook.com/v25.0/dialog/oauth?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });
@@ -657,10 +656,9 @@ test('facebook connect remembers the reconnect account from the query string', f
         ->andReturn($driverMock);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.facebook.connect', ['reconnect' => $account->id]));
 
-    $response->assertStatus(409);
+    $response->assertRedirect('https://www.facebook.com/v25.0/dialog/oauth?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id)
         ->and(session('social_reconnect_id'))->toBe($account->id);
@@ -685,9 +683,8 @@ test('facebook connect ignores a reconnect id from another workspace', function 
         ->andReturn($driverMock);
 
     $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.facebook.connect', ['reconnect' => $foreign->id]))
-        ->assertStatus(409);
+        ->assertRedirect('https://www.facebook.com/v25.0/dialog/oauth?test=1');
 
     expect(session('social_reconnect_id'))->toBeNull();
 });
@@ -712,9 +709,8 @@ test('facebook connect ignores a reconnect id from another network', function ()
         ->andReturn($driverMock);
 
     $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.facebook.connect', ['reconnect' => $linkedin->id]))
-        ->assertStatus(409);
+        ->assertRedirect('https://www.facebook.com/v25.0/dialog/oauth?test=1');
 
     expect(session('social_reconnect_id'))->toBeNull();
 });

--- a/tests/Feature/Social/FacebookControllerTest.php
+++ b/tests/Feature/Social/FacebookControllerTest.php
@@ -23,6 +23,14 @@ beforeEach(function () {
     $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
 });
 
+test('facebook authorize url reopens the page selection', function () {
+    $response = $this->actingAs($this->user)->get(route('app.social.facebook.connect'));
+
+    expect(urldecode((string) $response->headers->get('Location')))
+        ->toStartWith('https://www.facebook.com/')
+        ->toContain('auth_type=rerequest');
+});
+
 test('facebook connect redirects to oauth provider', function () {
     $driverMock = Mockery::mock();
     $driverMock->shouldReceive('usingGraphVersion')->andReturnSelf();

--- a/tests/Feature/Social/InstagramControllerTest.php
+++ b/tests/Feature/Social/InstagramControllerTest.php
@@ -43,10 +43,9 @@ test('instagram connect redirects to oauth provider', function () {
     $this->withoutExceptionHandling();
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.instagram.connect'));
 
-    $response->assertStatus(409);
+    $response->assertRedirect('https://www.instagram.com/oauth/authorize?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });

--- a/tests/Feature/Social/InstagramFacebookControllerTest.php
+++ b/tests/Feature/Social/InstagramFacebookControllerTest.php
@@ -37,10 +37,9 @@ test('instagram-facebook connect redirects to oauth provider', function () {
         ->andReturn($driverMock);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.instagram-facebook.connect'));
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    $response->assertRedirect('https://www.facebook.com/v25.0/dialog/oauth?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });

--- a/tests/Feature/Social/InstagramFacebookControllerTest.php
+++ b/tests/Feature/Social/InstagramFacebookControllerTest.php
@@ -22,6 +22,14 @@ beforeEach(function () {
     $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
 });
 
+test('instagram-facebook authorize url reopens the page selection', function () {
+    $response = $this->actingAs($this->user)->get(route('app.social.instagram-facebook.connect'));
+
+    expect(urldecode((string) $response->headers->get('Location')))
+        ->toStartWith('https://www.facebook.com/')
+        ->toContain('auth_type=rerequest');
+});
+
 test('instagram-facebook connect redirects to oauth provider', function () {
     $driverMock = Mockery::mock();
     $driverMock->shouldReceive('usingGraphVersion')->andReturnSelf();

--- a/tests/Feature/Social/LinkedInControllerTest.php
+++ b/tests/Feature/Social/LinkedInControllerTest.php
@@ -50,10 +50,9 @@ test('linkedin connect redirects to oauth provider via the openid driver', funct
         ->andReturn($driverMock);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.linkedin.connect'));
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    $response->assertRedirect('https://www.linkedin.com/oauth/v2/authorization?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });
@@ -82,7 +81,6 @@ function captureLinkedInConnectScopes(object $test): array
     Socialite::shouldReceive('driver')->with('linkedin-openid')->andReturn($driverMock);
 
     $test->actingAs($test->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.linkedin.connect'));
 
     return $captured;

--- a/tests/Feature/Social/LinkedInControllerTest.php
+++ b/tests/Feature/Social/LinkedInControllerTest.php
@@ -38,6 +38,15 @@ function linkedInSocialiteUser(string $id = 'person-123'): SocialiteUser
     return $socialiteUser;
 }
 
+test('linkedin authorize url carries the member and organization scopes', function () {
+    $response = $this->actingAs($this->user)->get(route('app.social.linkedin.connect'));
+
+    expect(urldecode((string) $response->headers->get('Location')))
+        ->toStartWith('https://www.linkedin.com/oauth/v2/authorization')
+        ->toContain('w_member_social')
+        ->toContain('rw_organization_admin');
+});
+
 test('linkedin connect redirects to oauth provider via the openid driver', function () {
     $driverMock = Mockery::mock();
     $driverMock->shouldReceive('scopes')->andReturnSelf();

--- a/tests/Feature/Social/MastodonControllerTest.php
+++ b/tests/Feature/Social/MastodonControllerTest.php
@@ -36,12 +36,12 @@ test('user can initiate mastodon oauth flow', function () {
     ]);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->post(route('app.social.mastodon.authorize'), [
             'instance' => 'https://mastodon.social',
         ]);
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    expect($response->headers->get('Location'))
+        ->toStartWith('https://mastodon.social/oauth/authorize');
 
     expect(session('mastodon_instance'))->toBe('https://mastodon.social');
     expect(session('mastodon_client_id'))->toBe('test-client-id');
@@ -244,12 +244,12 @@ test('mastodon works with custom instances', function () {
     ]);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->post(route('app.social.mastodon.authorize'), [
             'instance' => 'https://techhub.social',
         ]);
 
-    $response->assertStatus(409); // Inertia::location with X-Inertia header
+    expect($response->headers->get('Location'))
+        ->toStartWith('https://techhub.social/oauth/authorize');
 
     expect(session('mastodon_instance'))->toBe('https://techhub.social');
 });

--- a/tests/Feature/Social/PinterestControllerTest.php
+++ b/tests/Feature/Social/PinterestControllerTest.php
@@ -19,6 +19,15 @@ beforeEach(function () {
     $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
 });
 
+test('pinterest authorize url carries the publishing scopes', function () {
+    $response = $this->actingAs($this->user)->get(route('app.social.pinterest.connect'));
+
+    expect(urldecode((string) $response->headers->get('Location')))
+        ->toStartWith('https://www.pinterest.com/oauth')
+        ->toContain('boards:read')
+        ->toContain('pins:write');
+});
+
 test('pinterest connect redirects to oauth provider', function () {
     $driverMock = Mockery::mock();
     $driverMock->shouldReceive('scopes')->andReturnSelf();

--- a/tests/Feature/Social/PinterestControllerTest.php
+++ b/tests/Feature/Social/PinterestControllerTest.php
@@ -32,10 +32,9 @@ test('pinterest connect redirects to oauth provider', function () {
         ->andReturn($driverMock);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.pinterest.connect'));
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    $response->assertRedirect('https://www.pinterest.com/oauth?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });

--- a/tests/Feature/Social/ThreadsControllerTest.php
+++ b/tests/Feature/Social/ThreadsControllerTest.php
@@ -20,10 +20,10 @@ beforeEach(function () {
 
 test('threads connect redirects to oauth', function () {
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.threads.connect'));
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    expect($response->headers->get('Location'))
+        ->toStartWith('https://threads.net/oauth/authorize');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
     expect(session('threads_oauth_state'))->not->toBeNull();

--- a/tests/Feature/Social/TikTokControllerTest.php
+++ b/tests/Feature/Social/TikTokControllerTest.php
@@ -32,10 +32,9 @@ test('tiktok connect redirects to oauth provider', function () {
         ->andReturn($driverMock);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.tiktok.connect'));
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    $response->assertRedirect('https://www.tiktok.com/v2/auth/authorize?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });
@@ -202,9 +201,8 @@ test('tiktok connect carries a reconnect id into the session', function () {
     Socialite::shouldReceive('driver')->with('tiktok')->andReturn($driverMock);
 
     $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.tiktok.connect', ['reconnect' => $account->id]))
-        ->assertStatus(409);
+        ->assertRedirect('https://www.tiktok.com/v2/auth/authorize?test=1');
 
     expect(session('social_reconnect_id'))->toBe($account->id);
 });

--- a/tests/Feature/Social/TikTokControllerTest.php
+++ b/tests/Feature/Social/TikTokControllerTest.php
@@ -19,6 +19,14 @@ beforeEach(function () {
     $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
 });
 
+test('tiktok authorize url disables auto auth', function () {
+    $response = $this->actingAs($this->user)->get(route('app.social.tiktok.connect'));
+
+    expect(urldecode((string) $response->headers->get('Location')))
+        ->toStartWith('https://www.tiktok.com/v2/auth/authorize')
+        ->toContain('disable_auto_auth=1');
+});
+
 test('tiktok connect redirects to oauth provider', function () {
     $driverMock = Mockery::mock();
     $driverMock->shouldReceive('scopes')->andReturnSelf();

--- a/tests/Feature/Social/XControllerTest.php
+++ b/tests/Feature/Social/XControllerTest.php
@@ -32,10 +32,9 @@ test('x connect redirects to oauth provider', function () {
         ->andReturn($driverMock);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.x.connect'));
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    $response->assertRedirect('https://twitter.com/i/oauth2/authorize?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });

--- a/tests/Feature/Social/XControllerTest.php
+++ b/tests/Feature/Social/XControllerTest.php
@@ -19,6 +19,15 @@ beforeEach(function () {
     $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
 });
 
+test('x authorize url uses the current host and pkce', function () {
+    $response = $this->actingAs($this->user)->get(route('app.social.x.connect'));
+
+    expect(urldecode((string) $response->headers->get('Location')))
+        ->toStartWith('https://x.com/i/oauth2/authorize')
+        ->toContain('code_challenge_method=S256')
+        ->toContain('offline.access');
+});
+
 test('x connect redirects to oauth provider', function () {
     $driverMock = Mockery::mock();
     $driverMock->shouldReceive('scopes')->andReturnSelf();

--- a/tests/Feature/Social/YouTubeControllerTest.php
+++ b/tests/Feature/Social/YouTubeControllerTest.php
@@ -38,10 +38,9 @@ test('youtube connect redirects to oauth provider', function () {
         ->andReturn($driverMock);
 
     $response = $this->actingAs($this->user)
-        ->withHeader('X-Inertia', 'true')
         ->get(route('app.social.youtube.connect'));
 
-    $response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
+    $response->assertRedirect('https://accounts.google.com/o/oauth2/v2/auth?test=1');
 
     expect(session('social_connect_workspace'))->toBe($this->workspace->id);
 });

--- a/tests/Feature/Social/YouTubeControllerTest.php
+++ b/tests/Feature/Social/YouTubeControllerTest.php
@@ -21,6 +21,14 @@ beforeEach(function () {
     $this->workspace->members()->attach($this->user->id, ['role' => Role::Member->value]);
 });
 
+test('youtube authorize url offers the account chooser', function () {
+    $response = $this->actingAs($this->user)->get(route('app.social.youtube.connect'));
+
+    expect(urldecode((string) $response->headers->get('Location')))
+        ->toStartWith('https://accounts.google.com/')
+        ->toContain('prompt=select_account consent');
+});
+
 test('youtube connect redirects to oauth provider', function () {
     $driverMock = Mockery::mock();
     $driverMock->shouldReceive('scopes')->andReturnSelf();


### PR DESCRIPTION
## The trap

Every social connect test looked like this:

```php
$response = $this->actingAs($this->user)
    ->withHeader('X-Inertia', 'true')
    ->get(route('app.social.pinterest.connect'));

$response->assertStatus(409); // Inertia::location returns 409 with X-Inertia header
```

That 409 was never evidence of anything. The request sets `X-Inertia: true` but carries no `X-Inertia-Version`, so Inertia reads it as a version mismatch and answers **409 with `X-Inertia-Location` pointing back at the same URL** — after the controller has run. Any error inside the connect flow lands on the same 409, and the assertion passes either way.

Sixteen assertions across eleven files, none of which could tell a working redirect from a broken one.

How empty it was, concretely — dropping this into `redirectToProvider`, right after the session is remembered:

```php
throw new RuntimeException('REACHED');
```

left `x connect redirects to oauth provider` **green**. The session assertion still passed too, because `rememberConnectSession()` runs before the throw.

## The fix

Drop the header. Without it `Inertia::location()` returns a plain redirect, so the destination is assertable:

```php
$response->assertRedirect('https://www.pinterest.com/oauth?test=1');
```

Flows that mock Socialite assert against the mocked target. Threads and Mastodon build their authorize URL by hand, so those assert the endpoint they are supposed to reach (`https://threads.net/oauth/authorize`, `https://{instance}/oauth/authorize`).

## Verification

Each connect path was broken in turn — redirected to `https://example.com/BROKEN` — to confirm the tests covering it now fail:

| Path broken | Tests that failed |
| --- | --- |
| `SocialController::redirectToProvider` | Discord, Pinterest, TikTok (2), X |
| Facebook, IG-Facebook, Instagram, YouTube, LinkedIn, Threads, Mastodon `connect()` | 14 |
| `MastodonController::authorize` | 2 — the `connect()` probe does not reach this action |

All of those passed before this change.

Full suite: 4497 passed, 1 skipped. **No production code changes** — the diff is test files only.

## Origin

Found while working on #314; it was out of scope there and would have been lost otherwise.

---

## Second commit: assert the parameters actually reach the URL

The mocked connect tests prove `reRequest()` and `with()` were *called*:

```php
$driverMock->shouldReceive('reRequest')->once()->andReturnSelf();
```

They prove nothing about the URL Socialite builds. If a Socialite upgrade changed what `reRequest()` emits, those mocks stay green and the bug #314 fixed comes back with no warning.

Four tests now drive the real provider through the connect route:

```php
$response = $this->actingAs($this->user)->get(route('app.social.tiktok.connect'));

expect(urldecode((string) $response->headers->get('Location')))
    ->toStartWith('https://www.tiktok.com/v2/auth/authorize')
    ->toContain('disable_auto_auth=1');
```

They assert the parameter rather than the full URL, so a vendor bump of the authorize host (`v25.0` → `v26.0`) does not break them. Credentials come from the committed `.env.testing`, which CI loads via `APP_ENV=testing` in `phpunit.xml`.

Verified by removing each parameter in turn and confirming its test fails:

| Removed | Test that failed |
| --- | --- |
| `->reRequest()` (Facebook) | `facebook authorize url reopens the page selection` |
| `->reRequest()` (Instagram-Facebook) | `instagram-facebook authorize url reopens the page selection` |
| `disable_auto_auth => 1` | `tiktok authorize url disables auto auth` |
| `select_account consent` → `consent` | `youtube authorize url offers the account chooser` |

Instagram already had one of these from #314.

Full suite: 4501 passed, 1 skipped. Still no production code changes.

### Deliberately not done

Deriving these URLs from `config/trypost.php`. That config holds the **publishing** hosts — what the publishers and `ConnectionVerifier` call once an account is connected. The authorize URLs belong to **social login**, which comes from the Socialite provider and `config/services.php`.

`platforms.linkedin.oauth_api` shows why the distinction matters: it exists, `ConnectionVerifier.php:253` uses it for token refresh, and Socialite ignores it entirely — `LinkedInOpenIdProvider.php:28` hardcodes the same host. A config key for a vendor-owned authorize URL would be one a self-hoster could set with no effect.


---

## Third commit: every connect flow now hits the real authorize URL

Discord, Pinterest, X and LinkedIn were still covered only by a Socialite mock. A mock like that compares the fixture against itself, so it says nothing about the URL the app actually builds.

That the fixture drifts is not hypothetical. The X mock returns:

```
https://twitter.com/i/oauth2/authorize?test=1
```

The provider has been emitting `https://x.com/i/oauth2/authorize` for some time. No test noticed, because nothing ever compared the two.

Each new test pins what its flow depends on:

| Network | Pinned | Why it matters |
| --- | --- | --- |
| Discord | `scope=bot identify guilds`, `permissions=248832`, **no** `disable_guild_select` | that parameter would silence the server picker the same way Meta used to silence the page picker |
| X | `code_challenge_method=S256`, `offline.access` | no PKCE, no auth; no `offline.access`, no refresh token |
| Pinterest | `boards:read`, `pins:write` | publishing scopes |
| LinkedIn | `w_member_social`, `rw_organization_admin` | member and organization publishing |

Verified by breaking each and confirming its test fails: the bot scope in `DiscordProvider`, `offline.access` in `XController`, `pins:write` in `PinterestController`, the organization scopes in the LinkedIn config.

### Coverage after this PR

Every connect flow is now asserted against the URL the app really produces: Facebook, Instagram-Facebook, Instagram, Threads, Mastodon, TikTok, YouTube, Discord, Pinterest, X, LinkedIn.

The existing mock-based tests are kept — they still cover session handling, reconnect ids and the popup error paths, which the URL tests do not.

Full suite: 4505 passed, 1 skipped. No production code changes in this PR.
