### PR TITLE
Put Instagram Graph status on still-processing exceptions

### DIFF
--- a/app/Jobs/PublishToSocialPlatform.php
+++ b/app/Jobs/PublishToSocialPlatform.php
@@ -251,8 +251,10 @@ class PublishToSocialPlatform implements ShouldBeUnique, ShouldQueue
         Log::warning('Publish rescheduled: platform unavailable', [
             'post_platform_id' => $this->postPlatform->id,
             'platform' => $this->postPlatform->platform->value,
+            'content_type' => $this->postPlatform->content_type?->value,
             'next_attempt_at' => $nextAttemptAt->toIso8601String(),
             ...$context,
+            'media' => $this->mediaSnapshot($this->postPlatform),
         ]);
 
         $this->postPlatform->update([

--- a/app/Services/Social/InstagramPublisher.php
+++ b/app/Services/Social/InstagramPublisher.php
@@ -368,7 +368,12 @@ class InstagramPublisher
             throw $this->pendingContainerException($containerId, $workflow, $statusResponse->status());
         }
 
-        $statusCode = (string) ($statusResponse->json()['status_code'] ?? '');
+        $payload = $statusResponse->json();
+        $graphStatus = trim((string) data_get($payload, 'status', ''));
+        $statusCode = $this->resolveContainerStatusCode(
+            (string) data_get($payload, 'status_code', ''),
+            $graphStatus,
+        );
         $status = ContainerStatus::tryFrom($statusCode);
 
         return match ($status) {
@@ -383,8 +388,32 @@ class InstagramPublisher
                 $containerId,
                 $workflow,
                 statusCode: $statusCode !== '' ? $statusCode : null,
+                graphStatus: $graphStatus !== '' ? $graphStatus : null,
             ),
         };
+    }
+
+    /**
+     * Meta documents both fields; in practice ERROR sometimes arrives only
+     * as `status` ("Error: Media download has failed…") with an empty
+     * `status_code`. Treating that as still-processing burns the retry
+     * budget and Nightwatch only shows "still processing container".
+     */
+    private function resolveContainerStatusCode(string $statusCode, string $graphStatus): string
+    {
+        if ($statusCode !== '') {
+            return $statusCode;
+        }
+
+        if (ContainerStatus::tryFrom($graphStatus) instanceof ContainerStatus) {
+            return $graphStatus;
+        }
+
+        if (str_starts_with(strtolower($graphStatus), 'error')) {
+            return ContainerStatus::Error->value;
+        }
+
+        return '';
     }
 
     /**
@@ -469,7 +498,7 @@ class InstagramPublisher
     /**
      * @param  array<string, mixed>  $workflow
      */
-    private function pendingContainerException(string $containerId, array $workflow, ?int $httpStatus = null, ?string $statusCode = null): PlatformUnavailableException
+    private function pendingContainerException(string $containerId, array $workflow, ?int $httpStatus = null, ?string $statusCode = null, ?string $graphStatus = null): PlatformUnavailableException
     {
         $context = [PublishCheckpoint::INSTAGRAM_WORKFLOW => $workflow];
 
@@ -477,8 +506,23 @@ class InstagramPublisher
             $context[PublishCheckpoint::INSTAGRAM_STATUS] = $statusCode;
         }
 
+        if (is_string($graphStatus) && $graphStatus !== '') {
+            $context[PublishCheckpoint::INSTAGRAM_STATUS_DETAIL] = $graphStatus;
+        }
+
+        $detail = collect([
+            is_string($statusCode) && $statusCode !== '' ? "status_code={$statusCode}" : null,
+            is_string($graphStatus) && $graphStatus !== '' ? "status={$graphStatus}" : null,
+        ])->filter()->implode(', ');
+
+        $message = "Instagram is still processing container {$containerId}";
+
+        if ($detail !== '') {
+            $message .= " ({$detail})";
+        }
+
         return new PlatformUnavailableException(
-            message: "Instagram is still processing container {$containerId}",
+            message: $message,
             httpStatus: $httpStatus,
             context: $context,
             retryDelaySeconds: self::STATUS_RETRY_DELAY_SECONDS,

--- a/app/Support/Social/PublishCheckpoint.php
+++ b/app/Support/Social/PublishCheckpoint.php
@@ -21,6 +21,8 @@ final class PublishCheckpoint
 
     public const string INSTAGRAM_STATUS = 'instagram_status';
 
+    public const string INSTAGRAM_STATUS_DETAIL = 'instagram_status_detail';
+
     /**
      * @param  array<string, mixed>|null  $context
      */
@@ -69,6 +71,16 @@ final class PublishCheckpoint
     public static function instagramStatus(?array $context): ?string
     {
         $value = data_get($context, self::INSTAGRAM_STATUS);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $context
+     */
+    public static function instagramStatusDetail(?array $context): ?string
+    {
+        $value = data_get($context, self::INSTAGRAM_STATUS_DETAIL);
 
         return is_string($value) && $value !== '' ? $value : null;
     }

--- a/tests/Feature/Jobs/PublishToSocialPlatformTest.php
+++ b/tests/Feature/Jobs/PublishToSocialPlatformTest.php
@@ -472,7 +472,7 @@ test('publish reschedules platform unavailable retry via Bus dispatch (not marke
 
 test('publish warning log for an in-flight retry includes media and content type', function () {
     Bus::fake([PublishToSocialPlatform::class]);
-    Event::fake();
+    Event::fake([PostPlatformStatusUpdated::class]);
     Mail::fake();
 
     $this->post->update([

--- a/tests/Feature/Jobs/PublishToSocialPlatformTest.php
+++ b/tests/Feature/Jobs/PublishToSocialPlatformTest.php
@@ -470,6 +470,50 @@ test('publish reschedules platform unavailable retry via Bus dispatch (not marke
     });
 });
 
+test('publish warning log for an in-flight retry includes media and content type', function () {
+    Bus::fake([PublishToSocialPlatform::class]);
+    Event::fake();
+    Mail::fake();
+
+    $this->post->update([
+        'media' => [[
+            'url' => 'https://cdn.trypost.it/media/2026-01/clip.mp4',
+            'mime_type' => 'video/mp4',
+            'size' => 4_194_304,
+            'path' => 'media/2026-01/clip.mp4',
+            'original_filename' => 'clip.mp4',
+        ]],
+    ]);
+
+    $logs = [];
+    Log::listen(function (MessageLogged $event) use (&$logs): void {
+        $logs[] = $event;
+    });
+
+    $publisher = Mockery::mock(LinkedInPublisher::class);
+    $publisher->shouldReceive('publish')->andThrow(
+        new PlatformUnavailableException(
+            'Instagram is still processing container 18630170011019893 (status_code=IN_PROGRESS)',
+            context: ['instagram_status' => 'IN_PROGRESS'],
+        )
+    );
+    $this->app->instance(LinkedInPublisher::class, $publisher);
+
+    (new PublishToSocialPlatform($this->postPlatform->fresh()))->handle();
+
+    $entry = collect($logs)->first(
+        fn (MessageLogged $event): bool => $event->message === 'Publish rescheduled: platform unavailable'
+    );
+
+    expect($entry)->not->toBeNull()
+        ->and($entry->level)->toBe('warning')
+        ->and(data_get($entry->context, 'content_type'))->toBe('linkedin_post')
+        ->and(data_get($entry->context, 'instagram_status'))->toBe('IN_PROGRESS')
+        ->and(data_get($entry->context, 'media.0.url'))->toBe('https://cdn.trypost.it/media/2026-01/clip.mp4')
+        ->and(data_get($entry->context, 'media.0.mime_type'))->toBe('video/mp4')
+        ->and(data_get($entry->context, 'media.0.type'))->toBe('video');
+});
+
 test('publish reschedules when pinterest video processing times out', function () {
     Bus::fake([PublishToSocialPlatform::class]);
     Event::fake();

--- a/tests/Feature/Services/Social/InstagramPublisherTest.php
+++ b/tests/Feature/Services/Social/InstagramPublisherTest.php
@@ -744,16 +744,72 @@ test('instagram publisher does not publish a container that never finishes proce
 
     expect(fn () => $this->publisher->publish($this->postPlatform))
         ->toThrow(function (PlatformUnavailableException $exception): void {
-            expect($exception->context)->toBe([
-                'instagram_workflow' => [
-                    'stage' => 'final_container',
-                    'container_id' => 'container-123',
-                ],
-                'instagram_status' => 'IN_PROGRESS',
-            ]);
+            expect($exception->getMessage())->toBe('Instagram is still processing container container-123 (status_code=IN_PROGRESS)')
+                ->and($exception->context)->toBe([
+                    'instagram_workflow' => [
+                        'stage' => 'final_container',
+                        'container_id' => 'container-123',
+                    ],
+                    'instagram_status' => 'IN_PROGRESS',
+                ]);
         });
 
     Http::assertNotSent(fn ($request) => str_contains($request->url(), '/media_publish'));
+});
+
+test('instagram publisher puts the Graph status text on a still-processing exception', function () {
+    $this->post->update([
+        'media' => [[
+            'id' => 'test-media-id',
+            'path' => 'media/2026-01/test-image.jpg',
+            'url' => 'https://example.com/media/2026-01/test-image.jpg',
+            'mime_type' => 'image/jpeg',
+            'original_filename' => 'test.jpg',
+        ]],
+    ]);
+
+    Http::fake([
+        'https://graph.instagram.com/v25.0/ig_123456789/media' => Http::response(['id' => 'container-123']),
+        'https://graph.instagram.com/v25.0/container-123*' => Http::response([
+            'status_code' => 'IN_PROGRESS',
+            'status' => 'In progress: Media is still being processed.',
+        ]),
+    ]);
+
+    expect(fn () => $this->publisher->publish($this->postPlatform))
+        ->toThrow(function (PlatformUnavailableException $exception): void {
+            expect($exception->getMessage())->toBe(
+                'Instagram is still processing container container-123 (status_code=IN_PROGRESS, status=In progress: Media is still being processed.)'
+            )->and($exception->context['instagram_status'] ?? null)->toBe('IN_PROGRESS')
+                ->and($exception->context['instagram_status_detail'] ?? null)->toBe(
+                    'In progress: Media is still being processed.'
+                );
+        });
+});
+
+test('instagram publisher fails when Graph only returns an Error status string', function () {
+    $this->post->update([
+        'media' => [[
+            'id' => 'test-media-id',
+            'path' => 'media/2026-01/test-image.jpg',
+            'url' => 'https://example.com/media/2026-01/test-image.jpg',
+            'mime_type' => 'image/jpeg',
+            'original_filename' => 'test.jpg',
+        ]],
+    ]);
+
+    Http::fake([
+        'https://graph.instagram.com/v25.0/ig_123456789/media' => Http::response(['id' => 'container-123']),
+        'https://graph.instagram.com/v25.0/container-123*' => Http::response([
+            'status' => 'Error: Media download has failed. Please check the video URL.',
+        ]),
+    ]);
+
+    expect(fn () => $this->publisher->publish($this->postPlatform))
+        ->toThrow(function (InstagramPublishException $exception): void {
+            expect($exception->getMessage())->toBe('Instagram media processing failed')
+                ->and($exception->rawResponse)->toContain('Media download has failed');
+        });
 });
 
 test('instagram publisher retries a transient Graph rate-limit on container status', function (int $code) {

--- a/tests/Unit/Support/Social/PublishCheckpointTest.php
+++ b/tests/Unit/Support/Social/PublishCheckpointTest.php
@@ -45,3 +45,11 @@ test('instagramStatus reads a non-empty status', function () {
         ->and(PublishCheckpoint::instagramStatus(['instagram_status' => '']))->toBeNull()
         ->and(PublishCheckpoint::instagramStatus(null))->toBeNull();
 });
+
+test('instagramStatusDetail reads a non-empty Graph status', function () {
+    expect(PublishCheckpoint::instagramStatusDetail([
+        PublishCheckpoint::INSTAGRAM_STATUS_DETAIL => 'In progress: Media is still being processed.',
+    ]))->toBe('In progress: Media is still being processed.')
+        ->and(PublishCheckpoint::instagramStatusDetail(['instagram_status_detail' => '']))->toBeNull()
+        ->and(PublishCheckpoint::instagramStatusDetail(null))->toBeNull();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightwatch caught `PlatformUnavailableException: Instagram is still processing container 18630170011019893` on `PublishToSocialPlatform` (335ms, `social-instagram`). That is the **retry-exhausted** path — Instagram stayed non-terminal for the whole poll budget (~90 × 10s). Nightwatch Exceptions only stores class/message/stack, and this exception view had **Logs: Not captured**, so Graph `status_code` / `status` never appeared.

This change puts that payload on the exception itself so the next Nightwatch hit is readable without the log channel.

**What changed**
- Pending-container exception message now includes Graph `status_code` and `status` (e.g. `… (status_code=IN_PROGRESS, status=In progress: Media is still being processed.)`).
- `instagram_status_detail` is stored on the checkpoint next to `instagram_status`.
- If Graph returns only `status: "Error: Media download has failed…"` (empty `status_code`), we fail immediately as media-processing-failed instead of burning 15 minutes of retries.
- In-flight `Publish rescheduled: platform unavailable` warnings now include `content_type` and the media snapshot.

**Unchanged**
- User-facing emails (`posts.errors.platform_unavailable` / `platform_unavailable_exhausted` / `Instagram media processing failed`).
- In-flight retries still `Log::warning` only; `report()` still happens only when retries are exhausted.

After deploy, the Nightwatch exception message should carry the Graph status even when Logs stay empty.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09134-090c-78a8-98e7-bf8088ac5038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09134-090c-78a8-98e7-bf8088ac5038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

