### PR TITLE
Retry Threads text posts when the container is not found

### DIFF
--- a/app/Exceptions/Social/SocialPublishException.php
+++ b/app/Exceptions/Social/SocialPublishException.php
@@ -14,8 +14,9 @@ abstract class SocialPublishException extends RuntimeException
         public readonly ErrorCategory $category,
         public readonly ?string $platformErrorCode = null,
         public readonly ?string $rawResponse = null,
+        ?string $message = null,
     ) {
-        parent::__construct($userMessage);
+        parent::__construct($message ?? $userMessage);
     }
 
     /**

--- a/app/Exceptions/Social/ThreadsMediaContainerNotFoundException.php
+++ b/app/Exceptions/Social/ThreadsMediaContainerNotFoundException.php
@@ -19,14 +19,26 @@ final class ThreadsMediaContainerNotFoundException extends ThreadsPublishExcepti
             && $response->json('error.error_subcode') === self::ERROR_SUBCODE;
     }
 
-    public static function fromApiResponse(mixed $response): static
+    public static function fromApiResponse(mixed $response, ?string $containerId = null): static
     {
         /** @var Response $response */
+        $payload = $response->json();
+        $errorUserMsg = trim((string) data_get($payload, 'error.error_user_msg', ''));
+        $errorMessage = trim((string) data_get($payload, 'error.message', ''));
+        $userMessage = 'Threads could not find the processed media. Please try again.';
+        $detail = collect([
+            is_string($containerId) && $containerId !== '' ? "container_id={$containerId}" : null,
+            'code='.self::ERROR_CODE,
+            'error_subcode='.self::ERROR_SUBCODE,
+            $errorUserMsg !== '' ? "error_user_msg={$errorUserMsg}" : ($errorMessage !== '' ? "message={$errorMessage}" : null),
+        ])->filter()->implode(', ');
+
         return new self(
-            userMessage: 'Threads could not find the processed media. Please try again.',
+            userMessage: $userMessage,
             category: ErrorCategory::ServerError,
             platformErrorCode: (string) self::ERROR_CODE,
             rawResponse: $response->body(),
+            message: $detail !== '' ? "{$userMessage} ({$detail})" : $userMessage,
         );
     }
 }

--- a/app/Services/Social/ThreadsPublisher.php
+++ b/app/Services/Social/ThreadsPublisher.php
@@ -57,7 +57,9 @@ class ThreadsPublisher
                 );
             }
 
-            return $this->publishTextPost($userId, $accessToken, $content);
+            return $this->publishWithRetry(
+                fn (): array => $this->publishTextPost($userId, $accessToken, $content),
+            );
         }
 
         $firstMedia = $media->first();
@@ -66,18 +68,18 @@ class ThreadsPublisher
         // Single media
         if ($media->count() === 1) {
             if ($isVideo) {
-                return $this->publishMediaWithRetry(
+                return $this->publishWithRetry(
                     fn (): array => $this->publishVideoPost($userId, $accessToken, $content, $firstMedia),
                 );
             }
 
-            return $this->publishMediaWithRetry(
+            return $this->publishWithRetry(
                 fn (): array => $this->publishImagePost($userId, $accessToken, $content, $firstMedia),
             );
         }
 
         // Multiple media - carousel
-        return $this->publishMediaWithRetry(
+        return $this->publishWithRetry(
             fn (): array => $this->publishCarousel($userId, $accessToken, $content, $media),
         );
     }
@@ -280,7 +282,7 @@ class ThreadsPublisher
      * @param  callable(): array{id: string, url: ?string}  $publish
      * @return array{id: string, url: ?string}
      */
-    private function publishMediaWithRetry(callable $publish): array
+    private function publishWithRetry(callable $publish): array
     {
         for ($attempt = 1; $attempt <= self::MEDIA_PUBLICATION_MAX_ATTEMPTS; $attempt++) {
             try {
@@ -313,7 +315,7 @@ class ThreadsPublisher
 
         if ($publishResponse->failed()) {
             if (ThreadsMediaContainerNotFoundException::matches($publishResponse)) {
-                throw ThreadsMediaContainerNotFoundException::fromApiResponse($publishResponse);
+                throw ThreadsMediaContainerNotFoundException::fromApiResponse($publishResponse, $containerId);
             }
 
             Log::error('Threads publish failed', [

--- a/tests/Feature/Services/Social/ThreadsPublisherTest.php
+++ b/tests/Feature/Services/Social/ThreadsPublisherTest.php
@@ -172,6 +172,86 @@ test('threads publisher recreates a missing image container before retrying publ
     Log::shouldNotHaveReceived('error');
 });
 
+test('threads publisher recreates a missing text container before retrying publication', function () {
+    Log::spy();
+
+    $containerCreations = 0;
+    $publicationAttempts = 0;
+
+    Http::fake(function ($request) use (&$containerCreations, &$publicationAttempts) {
+        if (str_ends_with($request->url(), '/123456789/threads')) {
+            $containerCreations++;
+
+            return Http::response(['id' => "container-{$containerCreations}"], 200);
+        }
+
+        if (str_ends_with($request->url(), '/123456789/threads_publish')) {
+            $publicationAttempts++;
+
+            if ($publicationAttempts === 1) {
+                return Http::response([
+                    'error' => [
+                        'message' => 'The requested resource does not exist',
+                        'code' => 24,
+                        'error_subcode' => 4279009,
+                        'error_user_title' => 'Media Not Found',
+                        'error_user_msg' => 'The media with id container-1 cannot be found.',
+                    ],
+                ], 400);
+            }
+
+            return Http::response(['id' => 'post-after-retry'], 200);
+        }
+
+        return Http::response([
+            'permalink' => 'https://www.threads.net/@testuser/post/RETRY',
+        ], 200);
+    });
+
+    $result = $this->publisher->publish($this->postPlatform);
+
+    expect($result['id'])->toBe('post-after-retry')
+        ->and($containerCreations)->toBe(2)
+        ->and($publicationAttempts)->toBe(2);
+
+    Log::shouldHaveReceived('warning')->once();
+    Log::shouldNotHaveReceived('error');
+});
+
+test('threads publisher stops after three missing text containers', function () {
+    $publicationAttempts = 0;
+
+    Http::fake(function ($request) use (&$publicationAttempts) {
+        if (str_ends_with($request->url(), '/123456789/threads')) {
+            return Http::response(['id' => 'container-text'], 200);
+        }
+
+        if (str_ends_with($request->url(), '/123456789/threads_publish')) {
+            $publicationAttempts++;
+
+            return Http::response([
+                'error' => [
+                    'message' => 'The requested resource does not exist',
+                    'code' => 24,
+                    'error_subcode' => 4279009,
+                    'error_user_msg' => 'The media with id container-text cannot be found.',
+                ],
+            ], 400);
+        }
+
+        return Http::response([], 500);
+    });
+
+    expect(fn () => $this->publisher->publish($this->postPlatform))
+        ->toThrow(function (ThreadsMediaContainerNotFoundException $exception): void {
+            expect($exception->userMessage)->toBe('Threads could not find the processed media. Please try again.')
+                ->and($exception->getMessage())->toContain('container_id=container-text')
+                ->and($exception->getMessage())->toContain('error_user_msg=The media with id container-text cannot be found.');
+        });
+
+    expect($publicationAttempts)->toBe(3);
+});
+
 test('threads publisher does not retry a missing media response from container creation', function () {
     $this->post->update([
         'media' => [[

--- a/tests/Unit/Exceptions/Social/SocialPublishExceptionTest.php
+++ b/tests/Unit/Exceptions/Social/SocialPublishExceptionTest.php
@@ -92,6 +92,17 @@ test('exception message matches user message', function () {
     expect($exception->getMessage())->toBe('Rate limit exceeded.');
 });
 
+test('exception message can carry Nightwatch detail without changing userMessage', function () {
+    $exception = new TestPlatformException(
+        userMessage: 'Rate limit exceeded.',
+        category: ErrorCategory::RateLimit,
+        message: 'Rate limit exceeded. (code=4)',
+    );
+
+    expect($exception->userMessage)->toBe('Rate limit exceeded.')
+        ->and($exception->getMessage())->toBe('Rate limit exceeded. (code=4)');
+});
+
 test('fromApiResponse creates exception from response', function () {
     $exception = TestPlatformException::fromApiResponse(['error' => 'test']);
 

--- a/tests/Unit/Exceptions/Social/ThreadsMediaContainerNotFoundExceptionTest.php
+++ b/tests/Unit/Exceptions/Social/ThreadsMediaContainerNotFoundExceptionTest.php
@@ -27,7 +27,29 @@ test('matches code 24 subcode 4279009', function () {
     expect($exception->platformErrorCode)->toBe('24')
         ->and($exception->category)->toBe(ErrorCategory::ServerError)
         ->and($exception->userMessage)->toBe('Threads could not find the processed media. Please try again.')
+        ->and($exception->getMessage())->toBe(
+            'Threads could not find the processed media. Please try again. (code=24, error_subcode=4279009, error_user_msg=The media with id 17979429000118151 cannot be found.)'
+        )
         ->and($exception->rawResponse)->toContain('4279009');
+});
+
+test('fromApiResponse puts the container id on the Nightwatch message', function () {
+    $response = Http::response([
+        'error' => [
+            'message' => 'The requested resource does not exist',
+            'type' => 'OAuthException',
+            'code' => 24,
+            'error_subcode' => 4279009,
+            'error_user_msg' => 'The media with id 17979429000118151 cannot be found.',
+        ],
+    ], 400);
+
+    $fakeResponse = Http::fake(['*' => $response])->post('https://graph.threads.net/test');
+    $exception = ThreadsMediaContainerNotFoundException::fromApiResponse($fakeResponse, '17979429000118151');
+
+    expect($exception->userMessage)->toBe('Threads could not find the processed media. Please try again.')
+        ->and($exception->getMessage())->toContain('container_id=17979429000118151')
+        ->and($exception->getMessage())->toContain('error_user_msg=The media with id 17979429000118151 cannot be found.');
 });
 
 test('does not match code 24 without the missing media subcode', function () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nightwatch caught `ThreadsMediaContainerNotFoundException` on `PublishToSocialPlatform` (`social-threads`, 1.8s). The stack is `publishTextPost` → `publishContainer` — a **text-only** post, no media.

Graph `24` / `4279009` (“Media Not Found” / “The media with id … cannot be found”) is a known Threads race on `threads_publish`. Meta’s community reports it for **text as well as images**. Image, video, and carousel already recreate the container up to 3 times. Text did not, so the first miss became a hard fail and a generic Nightwatch message (`Logs: Not captured`).

**What changed**
- Text posts use the same `publishWithRetry` path as media.
- When all retries fail, Nightwatch’s exception message includes `container_id`, `code=24`, `error_subcode=4279009`, and Graph `error_user_msg`.
- `userMessage` (and therefore the email) stays `Threads could not find the processed media. Please try again.`

**Unchanged**
- User-facing copy.
- In-flight retries stay `Log::warning`; the job still `report()`s only the terminal `SocialPublishException`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a09134-090c-78a8-98e7-bf8088ac5038?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a09134-090c-78a8-98e7-bf8088ac5038&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

